### PR TITLE
PVS-Studio fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ x64/
 *.exe
 *.out
 *.app
+/msvc10/log4cplus.opensdf

--- a/tests/appender_test/main.cxx
+++ b/tests/appender_test/main.cxx
@@ -15,11 +15,11 @@ using namespace log4cplus;
 using namespace log4cplus::helpers;
 using namespace log4cplus::spi;
 
-void
-printAppenderList(SharedAppenderPtrList list)
+static void
+printAppenderList(const SharedAppenderPtrList& list)
 {
    cout << "List size: " << list.size() << endl;
-   for(SharedAppenderPtrList::iterator it=list.begin(); it!=list.end(); ++it) {
+   for(SharedAppenderPtrList::const_iterator it=list.begin(); it!=list.end(); ++it) {
        log4cplus::tcout << "Loop Body: Appender name = " << (*it)->getName()
                         << endl;
    }


### PR DESCRIPTION
- V813 Decreased performance. The 'list' argument should probably be rendered as a constant reference. main.cxx 19
- V808 'tmp' object of 'basic_string' type was created but was not utilized. main.cxx 51

Add .gitignore /msvc10/log4cplus.opensdf
