### PR TITLE
Github issue #33 - iOS build complier erros

### DIFF
--- a/iOS/scripts/cmake_ios_armv7.sh
+++ b/iOS/scripts/cmake_ios_armv7.sh
@@ -13,6 +13,7 @@ cmake -G "Xcode" -DBUILD_SHARED_LIBS="FALSE" \
                  -DLOG4CPLUS_BUILD_LOGGINGSERVER="OFF" \
                  -DLOG4CPLUS_CONFIGURE_CHECKS_PATH=$scripts_dir/../ConfigureChecks.cmake \
                  -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=$scripts_dir/../build_armv7/Binaries \
+                 -DCMAKE_CXX_FLAGS="-std=c++11"
                  $@ \
                  $scripts_dir/../..
 


### PR DESCRIPTION
iOS/scripts/cmake_ios_armv7.sh: Try to fix this by passing
CMAKE_CXX_FLAGS="-std=c++11".