### PR TITLE
Fix for bug #86 on GitHub.

### DIFF
--- a/src/fileappender.cxx
+++ b/src/fileappender.cxx
@@ -282,6 +282,9 @@ FileAppender::init(const tstring& filename_,
     helpers::LockFileGuard guard;
     if (useLockFile && ! lockFile.get ())
     {
+        if (createDirs)
+            internal::make_dirs (lockFileName_);
+
         try
         {
             lockFile.reset (new helpers::LockFile (lockFileName_));

--- a/tests/fileappender_test/main.cxx
+++ b/tests/fileappender_test/main.cxx
@@ -49,6 +49,20 @@ main()
         appender.setName (LOG4CPLUS_TEXT ("Third"));
     }
 
+    {
+        // This is checking that CreateDirs is respected when UseLockFile is
+        // provided and that directories for the lock file are created.
+        tistringstream propsStream (
+            LOG4CPLUS_TEXT("CreateDirs=true\n")
+            LOG4CPLUS_TEXT("File=./logs/some_name.log\n")
+            LOG4CPLUS_TEXT("UseLockFile=true\n")
+            LOG4CPLUS_TEXT("MaxFileSize=100MB\n")
+            LOG4CPLUS_TEXT("MaxBackupIndex=10\n"));
+        helpers::Properties props (propsStream);
+        FileAppender appender (props);
+        appender.setName (LOG4CPLUS_TEXT ("Fourth"));
+    }
+
     log4cplus::Logger::shutdown();
     return 0;
 }


### PR DESCRIPTION
fileappender.cxx: Create directories for lock file if CreateDirs is specified.

fileappender_test/main.cxx: Add a test for this.