### PR TITLE
TLS slot allocated in windows even when __declspec( thread ) used

### DIFF
--- a/include/log4cplus/thread/impl/tls.h
+++ b/include/log4cplus/thread/impl/tls.h
@@ -110,7 +110,11 @@ tls_cleanup (tls_key_type key)
 tls_key_type
 tls_init (tls_init_cleanup_func_type)
 {
+#if ! defined (LOG4CPLUS_THREAD_LOCAL_VAR)
     return TlsAlloc ();
+#else 
+    return (tls_key_type)0;	//TLS key not used
+#endif
 }
 
 


### PR DESCRIPTION
Visual studio,Windows > Vista: OS tls slot is allocated using TlsAlloc even when the new __declspec( thread ) is used. it doesn't get freed-resource leak