### PR TITLE
Fix GitHub bug #92.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,10 @@ if(NOT LOG4CPLUS_SINGLE_THREADED)
   message (STATUS "Threads: ${CMAKE_THREAD_LIBS_INIT}")
 endif(NOT LOG4CPLUS_SINGLE_THREADED)
 
+if(LOG4CPLUS_SINGLE_THREADED AND LOG4CPLUS_BUILD_LOGGINGSERVER)
+  message (FATAL_ERROR "The logging server requires the multi-thread capability.")
+endif(LOG4CPLUS_SINGLE_THREADED AND LOG4CPLUS_BUILD_LOGGINGSERVER)
+
 set(BUILD_SHARED_LIBS TRUE CACHE BOOL "If TRUE, log4cplus is built as a shared library, otherwise as a static library")
 
 if (WIN32)

--- a/msvc10/log4cplus_debug.props
+++ b/msvc10/log4cplus_debug.props
@@ -8,6 +8,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
   </ItemDefinitionGroup>
 </Project>

--- a/src/fileappender.cxx
+++ b/src/fileappender.cxx
@@ -34,6 +34,7 @@
 #include <algorithm>
 #include <sstream>
 #include <cstdio>
+#include <cmath>
 #include <stdexcept>
 
 #if defined (__BORLANDC__)
@@ -849,11 +850,16 @@ DailyRollingFileAppender::rollover(bool alreadyLocked)
 
 
 Time
-DailyRollingFileAppender::calculateNextRolloverTime(const Time& t) const
+DailyRollingFileAppender::calculateNextRolloverTime(const Time& t_) const
 {
+    // Round down the time to whole minutes.
+    Time const t (
+        t_.getTime ()
+        - static_cast<time_t>(std::fmod (t_.getTime (), 60)));
+
     switch(schedule)
     {
-    case MONTHLY: 
+    case MONTHLY:
     {
         struct tm nextMonthTime;
         t.localtime(&nextMonthTime);

--- a/src/fileappender.cxx
+++ b/src/fileappender.cxx
@@ -675,6 +675,30 @@ DailyRollingFileAppender::DailyRollingFileAppender(
 }
 
 
+namespace
+{
+
+
+static
+Time
+round_time (Time const & t, time_t seconds)
+{
+    return Time (
+        t.getTime ()
+        - static_cast<time_t>(std::fmod (t.getTime (), seconds)));
+}
+
+
+static
+Time
+round_time_and_add (Time const & t, Time const & seconds)
+{
+    return round_time (t, seconds.sec ()) + seconds;
+}
+
+
+} // namespace
+
 
 void
 DailyRollingFileAppender::init(DailyRollingFileSchedule sch)
@@ -850,13 +874,8 @@ DailyRollingFileAppender::rollover(bool alreadyLocked)
 
 
 Time
-DailyRollingFileAppender::calculateNextRolloverTime(const Time& t_) const
+DailyRollingFileAppender::calculateNextRolloverTime(const Time& t) const
 {
-    // Round down the time to whole minutes.
-    Time const t (
-        t_.getTime ()
-        - static_cast<time_t>(std::fmod (t_.getTime (), 60)));
-
     switch(schedule)
     {
     case MONTHLY:
@@ -872,14 +891,14 @@ DailyRollingFileAppender::calculateNextRolloverTime(const Time& t_) const
                 LOG4CPLUS_TEXT("DailyRollingFileAppender::calculateNextRolloverTime()-")
                 LOG4CPLUS_TEXT(" setTime() returned error"));
             // Set next rollover to 31 days in future.
-            ret = (t + Time(2678400));
+            ret = round_time (t, 24 * 60 * 60) + Time(2678400);
         }
 
         return ret;
     }
 
     case WEEKLY:
-        return (t + Time(7 * 24 * 60 * 60));
+        return round_time (t, 24 * 60 * 60) + Time (7 * 24 * 60 * 60);
 
     default:
         helpers::getLogLog ().error (
@@ -888,16 +907,16 @@ DailyRollingFileAppender::calculateNextRolloverTime(const Time& t_) const
         // Fall through.
 
     case DAILY:
-        return (t + Time(24 * 60 * 60));
+        return round_time_and_add (t, Time (24 * 60 * 60));
 
     case TWICE_DAILY:
-        return (t + Time(12 * 60 * 60));
+        return round_time_and_add (t, Time (12 * 60 * 60));
 
     case HOURLY:
-        return (t + Time(60 * 60));
+        return round_time_and_add (t, Time (60 * 60));
 
     case MINUTELY:
-        return (t + Time(60));
+        return round_time_and_add (t, Time (60));
     };
 }
 


### PR DESCRIPTION
Round time down to schedule granularity before computing next rollover time to avoid the rollover time drift.