### PR TITLE
Allow turning off library name decoration in CMake builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,20 +67,24 @@ option(ENABLE_SYMBOLS_VISIBILITY
 
 set(_WIN32_WINNT 0x0500 CACHE STRING "Define Windows API version to use.")
 
-if (NOT ${BUILD_SHARED_LIBS})
-  # set S-prefix for static build
-  set (log4cplus_postfix "${log4cplus_postfix}S")
-endif()
+option(LOG4CPLUS_ENABLE_DECORATED_LIBRARY_NAME
+  "Turns on resulting file name decoration for static and UNICODE builds." ON)
+if (LOG4CPLUS_ENABLE_DECORATED_LIBRARY_NAME)
+  if (NOT ${BUILD_SHARED_LIBS})
+    # set S-prefix for static build
+    set (log4cplus_postfix "${log4cplus_postfix}S")
+  endif ()
 
-if (UNICODE)
-  set (log4cplus_postfix "${log4cplus_postfix}U")
-endif (UNICODE)
+  if (UNICODE)
+    set (log4cplus_postfix "${log4cplus_postfix}U")
+  endif (UNICODE)
+endif (LOG4CPLUS_ENABLE_DECORATED_LIBRARY_NAME)
+
+set (log4cplus "log4cplus${log4cplus_postfix}")
 
 if (WITH_ICONV)
   set(LOG4CPLUS_WITH_ICONV 1)
 endif ()
-
-set (log4cplus "log4cplus${log4cplus_postfix}")
 
 if(LOG4CPLUS_CONFIGURE_CHECKS_PATH)
   get_filename_component(LOG4CPLUS_CONFIGURE_CHECKS_PATH "${LOG4CPLUS_CONFIGURE_CHECKS_PATH}" ABSOLUTE)


### PR DESCRIPTION
See also GitHub issue #98.

(cherry picked from commit ff24b0ae94f1b0f8c500f08e1bb300d7454275e8)