### PR TITLE
Added property "RotatePattern" to DailyRollingFileAppender settings

### DIFF
--- a/include/log4cplus/fileappender.h
+++ b/include/log4cplus/fileappender.h
@@ -285,6 +285,13 @@ namespace log4cplus
      * single logging period; e.g. how many <tt>log.2009-11-07.1</tt>,
      * <tt>log.2009-11-07.2</tt> etc. files are kept.</dd>
      *
+     * <dt><tt>RotatePattern</tt></dt>
+     * <dd>This property specifies filename suffix pattern to use for
+     * periodical backups of the logfile. The patern should be in
+     * format supported by {@link log4cplus::helpers::Time::getFormatterTime()}</code>.</dd>
+     * If the property isn't specified a reasonable default for a given
+     * schedule type is used.
+     *
      * </dl>
      */
     class LOG4CPLUS_EXPORT DailyRollingFileAppender : public FileAppender {
@@ -294,7 +301,8 @@ namespace log4cplus
                                  DailyRollingFileSchedule schedule = DAILY,
                                  bool immediateFlush = true,
                                  int maxBackupIndex = 10,
-                                 bool createDirs = false);
+                                 bool createDirs = false,
+                                 const log4cplus::tstring& rotatePattern = log4cplus::tstring());
         DailyRollingFileAppender(const log4cplus::helpers::Properties& properties);
 
       // Dtor
@@ -314,6 +322,7 @@ namespace log4cplus
         log4cplus::tstring scheduledFilename;
         log4cplus::helpers::Time nextRolloverTime;
         int maxBackupIndex;
+        log4cplus::tstring rotatePattern;
 
     private:
         LOG4CPLUS_PRIVATE void init(DailyRollingFileSchedule schedule);

--- a/src/fileappender.cxx
+++ b/src/fileappender.cxx
@@ -632,9 +632,10 @@ RollingFileAppender::rollover(bool alreadyLocked)
 
 DailyRollingFileAppender::DailyRollingFileAppender(
     const tstring& filename_, DailyRollingFileSchedule schedule_,
-    bool immediateFlush_, int maxBackupIndex_, bool createDirs_)
+    bool immediateFlush_, int maxBackupIndex_, bool createDirs_,
+    const tstring& rotatePattern_)
     : FileAppender(filename_, std::ios_base::app, immediateFlush_, createDirs_)
-    , maxBackupIndex(maxBackupIndex_)
+    , maxBackupIndex(maxBackupIndex_), rotatePattern(rotatePattern_)
 {
     init(schedule_);
 }
@@ -669,7 +670,8 @@ DailyRollingFileAppender::DailyRollingFileAppender(
             + properties.getProperty(LOG4CPLUS_TEXT("Schedule")));
         theSchedule = DAILY;
     }
-    
+
+    properties.getString (rotatePattern, LOG4CPLUS_TEXT("RotatePattern"));
     properties.getInt (maxBackupIndex, LOG4CPLUS_TEXT("MaxBackupIndex"));
 
     init(theSchedule);
@@ -929,38 +931,41 @@ tstring
 DailyRollingFileAppender::getFilename(const Time& t) const
 {
     tchar const * pattern = 0;
-    switch (schedule)
-    {
-    case MONTHLY:
-        pattern = LOG4CPLUS_TEXT("%Y-%m");
-        break;
+    if (rotatePattern.empty()) {
+        switch (schedule)
+        {
+        case MONTHLY:
+            pattern = LOG4CPLUS_TEXT("%Y-%m");
+            break;
 
-    case WEEKLY:
-        pattern = LOG4CPLUS_TEXT("%Y-%W");
-        break;
+        case WEEKLY:
+            pattern = LOG4CPLUS_TEXT("%Y-%W");
+            break;
 
-    default:
-        helpers::getLogLog ().error (
-            LOG4CPLUS_TEXT ("DailyRollingFileAppender::getFilename()-")
-            LOG4CPLUS_TEXT (" invalid schedule value"));
-        // Fall through.
+        default:
+            helpers::getLogLog ().error (
+                LOG4CPLUS_TEXT ("DailyRollingFileAppender::getFilename()-")
+                LOG4CPLUS_TEXT (" invalid schedule value"));
+            // Fall through.
 
-    case DAILY:
-        pattern = LOG4CPLUS_TEXT("%Y-%m-%d");
-        break;
+        case DAILY:
+            pattern = LOG4CPLUS_TEXT("%Y-%m-%d");
+            break;
 
-    case TWICE_DAILY:
-        pattern = LOG4CPLUS_TEXT("%Y-%m-%d-%p");
-        break;
+        case TWICE_DAILY:
+            pattern = LOG4CPLUS_TEXT("%Y-%m-%d-%p");
+            break;
 
-    case HOURLY:
-        pattern = LOG4CPLUS_TEXT("%Y-%m-%d-%H");
-        break;
+        case HOURLY:
+            pattern = LOG4CPLUS_TEXT("%Y-%m-%d-%H");
+            break;
 
-    case MINUTELY:
-        pattern = LOG4CPLUS_TEXT("%Y-%m-%d-%H-%M");
-        break;
-    };
+        case MINUTELY:
+            pattern = LOG4CPLUS_TEXT("%Y-%m-%d-%H-%M");
+            break;
+        };
+    } else
+        pattern = rotatePattern.c_str();
 
     tstring result (filename);
     result += LOG4CPLUS_TEXT(".");


### PR DESCRIPTION
The property controls the suffix of the backup files name. Previously
the suffix has been formed internally based on the schedule type.
This behavior is left intact if the property isn't specified.