### PR TITLE
Remove dependency from MinGW dll.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,6 @@ set (log4cplus_soversion 0)
 set (log4cplus_postfix "")
 
 option(LOG4CPLUS_BUILD_TESTING "Build the test suite." ON)
-
 option(LOG4CPLUS_BUILD_LOGGINGSERVER "Build the logging server." ON)
 
 if(NOT LOG4CPLUS_SINGLE_THREADED)
@@ -69,6 +68,10 @@ option(WITH_ICONV "Use iconv() for char->wchar_t conversion."
 option(ENABLE_SYMBOLS_VISIBILITY
   "Enable compiler and platform specific options for symbols visibility"
   ON)
+
+if (MINGW)
+  option(LOG4CPLUS_MINGW_STATIC_RUNTIME "Enable MinGW static runtime" OFF)
+endif()
 
 option(WITH_UNIT_TESTS "Enable unit tests" ON)
 if (WITH_UNIT_TESTS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -115,7 +115,7 @@ else ()
     COMPILE_FLAGS "-DINSIDE_LOG4CPLUS")
 endif ()
 
-if (MINGW)
+if (MINGW AND LOG4CPLUS_MINGW_STATIC_RUNTIME)
   # avoid dependency from mingw libstdc++/libgcc in resulting dll
   set_target_properties (${log4cplus} PROPERTIES
     LINK_FLAGS "-static -static-libgcc -static-libstdc++")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -115,6 +115,12 @@ else ()
     COMPILE_FLAGS "-DINSIDE_LOG4CPLUS")
 endif ()
 
+if (MINGW)
+  # avoid dependency from mingw libstdc++/libgcc in resulting dll
+  set_target_properties (${log4cplus} PROPERTIES
+    LINK_FLAGS "-static -static-libgcc -static-libstdc++")
+endif ()
+
 if (WIN32)
   set_target_properties (${log4cplus} PROPERTIES
     DEBUG_POSTFIX "D")


### PR DESCRIPTION
Environment: 
- Windows 10 64bit / MinGW-64 v5.3.0 / CMake 3.4.3

Build branch master with MinGW dll library depends on MinGW libstdc++ dll.

```
c:\WORK\GitHub\test\build.mingw\deps\bin>dumpbin /dependents liblog4cplus.dll
Microsoft (R) COFF/PE Dumper Version 12.00.31101.0
Copyright (C) Microsoft Corporation.  All rights reserved.


Dump of file liblog4cplus.dll

File Type: DLL

  Image has the following dependencies:

    ADVAPI32.dll
    libgcc_s_seh-1.dll
    KERNEL32.dll
    msvcrt.dll
    libwinpthread-1.dll
    USER32.dll
    WS2_32.dll
    libstdc++-6.dll
```

proposed change in cmake build will remove this dependency

```
c:\WORK\GitHub\test\build.mingw\deps\bin>dumpbin /dependents liblog4cplus.dll
Microsoft (R) COFF/PE Dumper Version 12.00.31101.0
Copyright (C) Microsoft Corporation.  All rights reserved.


Dump of file liblog4cplus.dll

File Type: DLL

  Image has the following dependencies:

    ADVAPI32.dll
    KERNEL32.dll
    msvcrt.dll
    USER32.dll
    WS2_32.dll
```

We can make it conditional or unconditional.