### PR TITLE
Added AppVeyor-CI for log4cplus

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ configuration.  It is modeled after the Java log4j API.
 
 [log4cplus]: https://sourceforge.net/projects/log4cplus/
 
+Branches        | Travis-CI      | AppVeyor-CI | 
+----------------|--------------- |-------------|-
+master          | [![Build Status](https://travis-ci.org/log4cplus/log4cplus.svg?branch=master)](https://travis-ci.org/log4cplus/log4cplus) | TBD |
+-------------------------------------------------
 
 Latest Project Information
 ==========================

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,28 @@
+version: 2.0.0.{build}
+
+install:
+    - git submodule update --init --recursive
+
+environment:
+    matrix:
+      #
+      # >>> Enable for 1.x
+      # - PRJ_GEN: "Visual Studio 11 2012 Win64"
+      #   BDIR: msvc2012
+      #   PRJ_CFG: Release
+        - PRJ_GEN: "Visual Studio 12 2013 Win64"
+          BDIR: msvc2013
+          PRJ_CFG: Release
+        - PRJ_GEN: "Visual Studio 14 2015 Win64"
+          BDIR: msvc2015
+          PRJ_CFG: Release
+
+build_script:
+    - mkdir build.%BDIR%
+    - cd build.%BDIR%
+    - cmake .. -G"%PRJ_GEN%" -DCMAKE_BUILD_TYPE=%PRJ_CFG%
+    - cmake --build . --config %PRJ_CFG% --clean-first
+
+test_script:
+    - ctest -V --output-on-failure -C %PRJ_CFG%
+


### PR DESCRIPTION
Added AppVeyor-CI for Log4cplus

After the merge, it is required to enable it in the service https://ci.appveyor.com