### PR TITLE
Fix cmake_minimum_required to be 2.8.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ endif ()
 set (CMAKE_LEGACY_CYGWIN_WIN32 0)
 
 project (log4cplus)
-cmake_minimum_required (VERSION 2.8.4)
+cmake_minimum_required (VERSION 2.8.12)
 
 enable_language (CXX)
 include(GNUInstallDirs)


### PR DESCRIPTION
The src/CMakeLists.txt makes use of the `INCLUDES DESTINATION` install
argument which was introduced into CMake with rev '650e61f'.
The first CMake release including this rev is 2.8.12.

Thus the minimum required CMake version must be adjusted to 2.8.12.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>