### PR TITLE
Guarded set of CMP0054 with version check

### DIFF
--- a/ConfigureChecks.cmake
+++ b/ConfigureChecks.cmake
@@ -1,4 +1,7 @@
-cmake_policy(SET CMP0054 NEW)
+if (NOT CMAKE_VERSION VERSION_LESS 3.1.0)
+  cmake_policy(SET CMP0054 NEW)
+endif()
+
 include(CheckIncludeFiles)
 include(CheckFunctionExists)
 include(CheckLibraryExists)


### PR DESCRIPTION
CMP0054 was introduced in CMake 3.1.0 and therefore attempting to set it in earlier version would result in a broken build. There's no need in updating cmake_minimum_required since it's not a crucial feature and some people might still use older versions of CMake.