### PR TITLE
Fix 366c4af2af1b8f7d91efd528f1b080cd7cb580fc.

### DIFF
--- a/configure
+++ b/configure
@@ -10585,6 +10585,7 @@ fi
 
 fi
 
+         if test "$target_os" != "darwin" -o "$target_cpu" != "arm"; then :
 
 
 
@@ -10756,6 +10757,8 @@ $as_echo "$ac_cv_declspec_thread" >&6; }
 fi
 fi
 
+
+fi
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -538,8 +538,9 @@ dnl Multi threaded library.
 
    dnl Check if TLS is supported, but only if it isn't iOS target, because it
    dnl is forbidden by Apple Store to use __tlv_* functions.
-   AS_IF([test "$target_os" != "darwin" -o "$target_cpu" != "arm",
-     [AX_TLS_SUPPORT]])
+   AS_IF([test "$target_os" != "darwin" -o "$target_cpu" != "arm"],
+     [AX_TLS_SUPPORT])
+
    AH_TEMPLATE([LOG4CPLUS_HAVE_TLS_SUPPORT])
    AH_TEMPLATE([LOG4CPLUS_THREAD_LOCAL_VAR])
    AS_IF([test "x$ac_cv_thread_local" = "xyes"],


### PR DESCRIPTION
Fix braces nesting. Regenerate the `configure` script.