### PR TITLE
fix TimeBasedRollingFileAppender forget init

### DIFF
--- a/src/fileappender.cxx
+++ b/src/fileappender.cxx
@@ -1214,7 +1214,10 @@ TimeBasedRollingFileAppender::TimeBasedRollingFileAppender(
     , maxHistory(maxHistory_)
     , cleanHistoryOnStart(cleanHistoryOnStart_)
     , rollOnClose(rollOnClose_)
-{ }
+{
+	filenamePattern = preprocessFilenamePattern(filenamePattern, schedule);
+	init();
+}
 
 TimeBasedRollingFileAppender::TimeBasedRollingFileAppender(
     const log4cplus::helpers::Properties& properties)


### PR DESCRIPTION
fix TimeBasedRollingFileAppender forget init when Ctor without log4cplus::helpers::Properties