### PR TITLE
Initializing default_context

### DIFF
--- a/src/global-init.cxx
+++ b/src/global-init.cxx
@@ -155,8 +155,8 @@ enum DCState
 };
 
 
-static DCState default_context_state;
-static DefaultContext * default_context;
+static DCState default_context_state = DC_UNINITIALIZED;
+static DefaultContext * default_context = nullptr;
 
 
 struct destroy_default_context


### PR DESCRIPTION
withouth initializing this pointer, line 166 in global-init.cxx will
cause an error down the call stack. (visual c++ 2015 debug mode)