### PR TITLE
CMakeLists.txt: use ${CMAKE_INSTALL_LIBDIR} instead of hardcoding lib

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -132,7 +132,7 @@ endif ()
 ###
 # Installation (https://github.com/forexample/package-example)
 
-set(config_install_dir "lib/cmake/${PROJECT_NAME}")
+set(config_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 
 set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
 


### PR DESCRIPTION
Fixes aarch64 build with multilib enabled - ${CMAKE_INSTALL_LIBDIR} is than
lib64.

Signed-off-by: Radek Dostál <radek.dostal@streamunlimited.com>