### PR TITLE
Fix static_assert for Mac OS X compilation.

### DIFF
--- a/include/log4cplus/helpers/timehelper.h
+++ b/include/log4cplus/helpers/timehelper.h
@@ -110,7 +110,7 @@ inline
 long
 microseconds_part (Time const & the_time)
 {
-    static_assert (std::ratio_equal<Duration::period, std::micro>::value,
+    static_assert ((std::ratio_equal<Duration::period, std::micro>::value),
         "microseconds");
 
     // This is based on <http://stackoverflow.com/a/17395137/341065>


### PR DESCRIPTION
Note that this issue is breaking downstream projects e.g. openalpr doesn't compile out of the box correctly today:

https://github.com/openalpr/openalpr/issues/658