### PR TITLE
Proposal: LOG4CPLUS_MACRO_FILE similar to LOG4CPLUS_MACRO_FUNCTION

### DIFF
--- a/include/log4cplus/loggingmacros.h
+++ b/include/log4cplus/loggingmacros.h
@@ -158,6 +158,13 @@ LOG4CPLUS_EXPORT void macro_forced_log (log4cplus::Logger const &,
 #  endif
 #endif
 
+#undef LOG4CPLUS_MACRO_FILE
+#define LOG4CPLUS_MACRO_FILE() nullptr
+#if ! defined (LOG4CPLUS_DISABLE_FILE_MACRO)
+#  undef LOG4CPLUS_MACRO_FILE
+#  define LOG4CPLUS_MACRO_FILE() __FILE__
+#endif
+
 
 // Make TRACE and DEBUG log level unlikely and INFO, WARN, ERROR and
 // FATAL log level likely.
@@ -212,7 +219,8 @@ LOG4CPLUS_EXPORT void macro_forced_log (log4cplus::Logger const &,
             _log4cplus_buf << logEvent;                                 \
             log4cplus::detail::macro_forced_log (_l,                    \
                 log4cplus::logLevel, _log4cplus_buf.str(),              \
-                __FILE__, __LINE__, LOG4CPLUS_MACRO_FUNCTION ());       \
+                LOG4CPLUS_MACRO_FILE (), __LINE__,                      \
+                LOG4CPLUS_MACRO_FUNCTION ());                           \
         }                                                               \
     } while (0)                                                         \
     LOG4CPLUS_RESTORE_DOWHILE_WARNING()
@@ -227,7 +235,8 @@ LOG4CPLUS_EXPORT void macro_forced_log (log4cplus::Logger const &,
                 _l.isEnabledFor (log4cplus::logLevel), logLevel)) {     \
             log4cplus::detail::macro_forced_log (_l,                    \
                 log4cplus::logLevel, logEvent,                          \
-                __FILE__, __LINE__, LOG4CPLUS_MACRO_FUNCTION ());       \
+                LOG4CPLUS_MACRO_FILE (), __LINE__,                      \
+                LOG4CPLUS_MACRO_FUNCTION ());                           \
         }                                                               \
     } while(0)                                                          \
     LOG4CPLUS_RESTORE_DOWHILE_WARNING()
@@ -244,7 +253,8 @@ LOG4CPLUS_EXPORT void macro_forced_log (log4cplus::Logger const &,
                 = _snpbuf.print (__VA_ARGS__);                          \
             log4cplus::detail::macro_forced_log (_l,                    \
                 log4cplus::logLevel, _logEvent,                         \
-                __FILE__, __LINE__, LOG4CPLUS_MACRO_FUNCTION ());       \
+                LOG4CPLUS_MACRO_FILE (), __LINE__,                      \
+                LOG4CPLUS_MACRO_FUNCTION ());                           \
         }                                                               \
     } while(0)                                                          \
     LOG4CPLUS_RESTORE_DOWHILE_WARNING()
@@ -258,7 +268,8 @@ LOG4CPLUS_EXPORT void macro_forced_log (log4cplus::Logger const &,
 #if !defined(LOG4CPLUS_DISABLE_TRACE)
 #define LOG4CPLUS_TRACE_METHOD(logger, logEvent)                        \
     log4cplus::TraceLogger _log4cplus_trace_logger(logger, logEvent,    \
-        __FILE__, __LINE__, LOG4CPLUS_MACRO_FUNCTION ());
+        LOG4CPLUS_MACRO_FILE (), __LINE__,                              \
+        LOG4CPLUS_MACRO_FUNCTION ());
 #define LOG4CPLUS_TRACE(logger, logEvent)                               \
     LOG4CPLUS_MACRO_BODY (logger, logEvent, TRACE_LOG_LEVEL)
 #define LOG4CPLUS_TRACE_STR(logger, logEvent)                           \


### PR DESCRIPTION
I propose a macro LOG4CPLUS_MACRO_FILE similar to LOG4CPLUS_MACRO_FUNCTION.

Purpose: Because __FILE__ is used directly, every filename that logs something will be compiled into the binary. In some cases, this can be undesirable.
For example, I have a file in which strings are obfuscated (using https://github.com/andrivet/ADVobfuscator/), but currently the filename still shows up in the binary.

The macro LOG4CPLUS_MACRO_FILE allows undefining __FILE__ to something else or not using it in specific cases.