### PR TITLE
src/clogger.cxx: remove unused local variable

### DIFF
--- a/src/clogger.cxx
+++ b/src/clogger.cxx
@@ -44,7 +44,6 @@ using namespace log4cplus::helpers;
 LOG4CPLUS_EXPORT void *
 log4cplus_initialize(void)
 {
-    Initializer * initializer = 0;
     try
     {
         return new Initializer();


### PR DESCRIPTION
Local variable (likely intended for backward compatibility)
`initializer` removed to avoid compile warning.

Signed-off-by: Jens Rehsack <sno@netbsd.org>