### PR TITLE
config.hxx: fix threadpool compiling

### DIFF
--- a/include/log4cplus/config.hxx
+++ b/include/log4cplus/config.hxx
@@ -178,6 +178,8 @@
 #endif
 
 #if defined(__cplusplus)
+#include <cstddef>
+
 namespace log4cplus
 {
 


### PR DESCRIPTION
In commit e73dc3fb8cf9b8734df05406798781a4f56c067e
Author: Jens Rehsack <sno@netbsd.org>
Date:   Sun Nov 11 19:33:23 2018 +0100

    config.hxx: fix C API compiling

the removed cstddef wasn't added back in c++ section.

Signed-off-by: Jens Rehsack <sno@netbsd.org>