### PR TITLE
Added existing function shutdownThreadPool() to the API and added new…

### DIFF
--- a/include/log4cplus/config.hxx
+++ b/include/log4cplus/config.hxx
@@ -203,6 +203,22 @@ LOG4CPLUS_EXPORT void deinitialize ();
 //! Set thread pool size.
 LOG4CPLUS_EXPORT void setThreadPoolSize (std::size_t pool_size);
 
+//! Shuts down the thread pool. 
+//! This function should be called in the special case the user wants to (temporarily) 
+//! shutdown the thread pool and delete its threads. 
+//! Such a case is if a process wants to create a new child process by calling fork() (without exec). 
+//! In this case the user should call this function before fork(), to prevent the created child 
+//! processs to hang on exit. If this function is not called before fork(), the child process will
+//! inherit a copy of the ThreadPool from the parent process, without its threads, which eventually
+//! results in the child to block on exit during the the destruction of ThreadPool.
+//! After forking the user must call restartThreadPool() before to continue using log4cplus.
+LOG4CPLUS_EXPORT void shutdownThreadPool ();
+
+//! Shuts down the current thread pool, if it exists, and starts a new one.
+//! One case where this is necessary is if the user wants to continue using log4cplus after calling
+//! shutdownThreadPool().
+LOG4CPLUS_EXPORT void restartThreadPool ();
+
 } // namespace log4cplus
 
 #endif

--- a/src/global-init.cxx
+++ b/src/global-init.cxx
@@ -98,9 +98,6 @@ Initializer::Initializer ()
 }
 
 
-// Forward declaration. Defined in this file.
-void shutdownThreadPool();
-
 Initializer::~Initializer ()
 {
     bool destroy = false;
@@ -283,6 +280,13 @@ void
 shutdownThreadPool ()
 {
     LOG4CPLUS_THREADED (get_dc ()->thread_pool.reset ());
+}
+
+
+void
+restartThreadPool ()
+{
+    LOG4CPLUS_THREADED (get_dc()->thread_pool.reset(new  progschj::ThreadPool));
 }
 
 


### PR DESCRIPTION
… function restartThreadPool(), which can be called to reset the thread pool after shutting it down through shutdownThreadPool().

This change makes it possible to use log4cplus in applications that use forking (without exec). Since calling fork() doesnt result in threads to be copied over to the child process, and the thread pool is already initialized by default in the parent process, the thread pool in the child process will be in an invalid state as its workers vector is not empty but those worker threads actually dont exist. This bug is especially noticable when trying to exit the child process, the destructor of ThreadPool is then called but waits forever on a conditionto become true, which will never happen. By calling shutdownThreadPool before fork() and then restartThreadPool() right after fork() inside the child and the parent process, both processes can continue using log4cplus correctly.

Original problem, example program:
```
    Initializer initializer;

    pid_t p = fork();

    if (p == 0)
    {
        // child process
        exit(0);
    }

    // parent process
    return 0;
```

results in child process to hang:
```
#0  pthread_cond_wait@@GLIBC_2.3.2 () at ../sysdeps/unix/sysv/linux/x86_64/pthread_cond_wait.S:185
#1  0x00007f77ad22379c in std::condition_variable::wait(std::unique_lock<std::mutex>&) () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#2  0x00007f77ad5add36 in std::condition_variable::wait<progschj::ThreadPool::~ThreadPool()::{lambda()#1}>(std::unique_lock<std::mutex>&, progschj::ThreadPool::~ThreadPool()::{lambda()#1}) (
    this=0x625ab8, __lock=..., __p=...) at /usr/include/c++/7/condition_variable:99
#3  0x00007f77ad5ac8ad in progschj::ThreadPool::~ThreadPool (this=0x6259e0, __in_chrg=<optimised out>) at ./threadpool/ThreadPool.h:157
#4  0x00007f77ad5af536 in std::default_delete<progschj::ThreadPool>::operator() (this=0x6258d8, __ptr=0x6259e0) at /usr/include/c++/7/bits/unique_ptr.h:78
#5  0x00007f77ad5ae125 in std::unique_ptr<progschj::ThreadPool, std::default_delete<progschj::ThreadPool> >::~unique_ptr (this=0x6258d8, __in_chrg=<optimised out>)
    at /usr/include/c++/7/bits/unique_ptr.h:268
#6  0x00007f77ad5a7b16 in log4cplus::(anonymous namespace)::DefaultContext::~DefaultContext (this=0x625690, __in_chrg=<optimised out>) at src/global-init.cxx:130
#7  0x00007f77ad5a7bd3 in log4cplus::(anonymous namespace)::destroy_default_context::~destroy_default_context (this=0x7f77ad823a58 <log4cplus::(anonymous namespace)::destroy_default_context_>, 
    __in_chrg=<optimised out>) at src/global-init.cxx:165
#8  0x00007f77acbc436a in __cxa_finalize (d=0x7f77ad8239a0) at cxa_finalize.c:56
#9  0x00007f77ad57e613 in __do_global_dtors_aux () from /home/ldejong/log4cplus-2.0.2/target/lib/liblog4cplus-2.0.so.3
#10 0x00007fffd1fcc7c0 in ?? ()
#11 0x00007f77ad834de7 in _dl_fini () at dl-fini.c:235
```

With this commit it is possible to fork and use log4cplus:

```
    Initializer initializer;

    shutdownThreadPool();
    pid_t p = fork();
    restartThreadPool();
    if (p == 0)
    {
        // use log4cplus ...
        exit(0);
    }

     // use log4cplus ...
    return 0;
```