### PR TITLE
Fix complication error when included from .c file.

### DIFF
--- a/include/log4cplus/config.hxx
+++ b/include/log4cplus/config.hxx
@@ -31,7 +31,11 @@
 #else
 #  include <log4cplus/config/defines.hxx>
 #endif
+#ifdef __cplusplus
 #include <cstddef>
+#else // __cplusplus
+#include <stddef.h>
+#endif
 
 # if ! defined (LOG4CPLUS_WORKING_LOCALE) \
   && ! defined (LOG4CPLUS_WORKING_C_LOCALE) \

--- a/include/log4cplus/config.hxx
+++ b/include/log4cplus/config.hxx
@@ -33,9 +33,7 @@
 #endif
 #ifdef __cplusplus
 #include <cstddef>
-#else // __cplusplus
-#include <stddef.h>
-#endif
+#endif // __cplusplus
 
 # if ! defined (LOG4CPLUS_WORKING_LOCALE) \
   && ! defined (LOG4CPLUS_WORKING_C_LOCALE) \


### PR DESCRIPTION
c compilers could not find cstddef file, include stddef.h if __cplusplus macro not defined.
sorry for my poor English :)