### PR TITLE
configure.ac: add an option to disable tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -50,6 +50,7 @@ include %D%/qt5debugappender/Makefile.am
 include %D%/swig/Makefile.common.am
 include %D%/swig/python/Makefile.am
 
+if ENABLE_TESTS
 include %D%/tests/Makefile.am
 include %D%/tests/appender_test/Makefile.am
 include %D%/tests/configandwatch_test/Makefile.am
@@ -68,4 +69,5 @@ include %D%/tests/socket_test/Makefile.am
 include %D%/tests/thread_test/Makefile.am
 include %D%/tests/timeformat_test/Makefile.am
 include %D%/tests/unit_tests/Makefile.am
+endif
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,12 @@ separate shared library (liblog4cplusqt4debugappender) that implements
 `Qt4DebugAppender`.  It requires Qt4 and pkg-config to be installed.
 
 
+`--enable-tests`
+---------------------
+
+This option is enabled by default.  It enables compilation of test executables.
+
+
 `--enable-unit-tests`
 ---------------------
 

--- a/configure.ac
+++ b/configure.ac
@@ -126,6 +126,13 @@ AM_CONDITIONAL([BUILD_WITH_WCHAR_T_SUPPORT],
 AS_VAR_SET([BUILD_WITH_WCHAR_T_SUPPORT], [$with_wchar_t_support])
 AC_SUBST([BUILD_WITH_WCHAR_T_SUPPORT])
 
+dnl Enable tests
+LOG4CPLUS_ARG_ENABLE([tests],
+  [Enable tests [default=yes]],
+  [enable_tests=yes])
+AM_CONDITIONAL([ENABLE_TESTS],
+  [test "x$enable_tests" = "xyes"])
+
 dnl Enable unit tests
 
 LOG4CPLUS_ARG_ENABLE([unit-tests],


### PR DESCRIPTION
Allow the user to disable tests in configure.ac (this is already
possible through cmake with LOG4CPLUS_BUILD_TESTING)

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>