### PR TITLE
configure.ac: link with libatomic when needed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -403,6 +403,7 @@ LOG4CPLUS_DEFINE_MACRO_IF([LOG4CPLUS_HAVE_VAR_ATTRIBUTE_INIT_PRIORITY],
 
 dnl Checks for libraries.
 
+AC_SEARCH_LIBS([__atomic_fetch_and_4], [atomic])
 AC_SEARCH_LIBS([strerror], [cposix])
 dnl On some systems libcompat exists only as a static library which
 dnl breaks compilation of shared library log4cplus.


### PR DESCRIPTION
On some architectures, atomic binutils are provided by the libatomic
library from gcc. Linking with libatomic is therefore necessary,
otherwise the build fails with:

sparc-buildroot-linux-uclibc/sysroot/lib/libatomic.so.1: error adding
symbols: DSO missing from command line

This is often for example the case on sparcv8 32 bit.

Fixes:
 - http://autobuild.buildroot.org/results/16e360cb91afff7655f459a3d1fb906ca48f8464

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>