### PR TITLE
fix build with Intel compiler

### DIFF
--- a/src/version.cxx
+++ b/src/version.cxx
@@ -37,7 +37,7 @@ char const versionStr[] = LOG4CPLUS_VERSION_STR LOG4CPLUS_VERSION_STR_SUFFIX;
 namespace
 {
 
-#if defined (__ELF__) && (defined (__GNUC__) || defined (__clang__))
+#if defined (__ELF__) && (defined (__GNUC__) || defined (__clang__)) && !defined(__INTEL_COMPILER)
 char const versionStrComment[]
     __attribute__ ((__used__, __section__ ((".comment"))))
     = "log4cplus " LOG4CPLUS_VERSION_STR LOG4CPLUS_VERSION_STR_SUFFIX;


### PR DESCRIPTION
icpc 15.0.6 otherwise complains "version.cxx(42): error: expected a string literal"
  at the start of ".comment"

Alex