### PR TITLE
Integrate Clang Tidy fixes.

### DIFF
--- a/src/appender.cxx
+++ b/src/appender.cxx
@@ -419,7 +419,7 @@ Appender::getErrorHandler()
 void
 Appender::setErrorHandler(std::unique_ptr<ErrorHandler> eh)
 {
-    if (! eh.get())
+    if (! eh)
     {
         // We do not throw exception here since the cause is probably a
         // bad config file.

--- a/src/appender.cxx
+++ b/src/appender.cxx
@@ -39,12 +39,10 @@ namespace log4cplus
 // log4cplus::ErrorHandler dtor
 ///////////////////////////////////////////////////////////////////////////////
 
-ErrorHandler::ErrorHandler ()
-{ }
+ErrorHandler::ErrorHandler () = default;
 
 
-ErrorHandler::~ErrorHandler()
-{ }
+ErrorHandler::~ErrorHandler() = default;
 
 
 
@@ -57,8 +55,7 @@ OnlyOnceErrorHandler::OnlyOnceErrorHandler()
 { }
 
 
-OnlyOnceErrorHandler::~OnlyOnceErrorHandler ()
-{ }
+OnlyOnceErrorHandler::~OnlyOnceErrorHandler () = default;
 
 
 void

--- a/src/appender.cxx
+++ b/src/appender.cxx
@@ -102,7 +102,6 @@ Appender::Appender()
 
 Appender::Appender(const log4cplus::helpers::Properties & properties)
     : layout(new SimpleLayout)
-    , name()
     , threshold(NOT_SET_LOG_LEVEL)
     , errorHandler(new OnlyOnceErrorHandler)
     , useLockFile(false)

--- a/src/appenderattachableimpl.cxx
+++ b/src/appenderattachableimpl.cxx
@@ -36,8 +36,7 @@ namespace spi
 {
 
 
-AppenderAttachable::~AppenderAttachable()
-{ }
+AppenderAttachable::~AppenderAttachable() = default;
 
 
 } // namespace spi
@@ -51,12 +50,10 @@ namespace helpers
 // log4cplus::helpers::AppenderAttachableImpl ctor and dtor
 //////////////////////////////////////////////////////////////////////////////
 
-AppenderAttachableImpl::AppenderAttachableImpl()
-{ }
+AppenderAttachableImpl::AppenderAttachableImpl() = default;
 
 
-AppenderAttachableImpl::~AppenderAttachableImpl()
-{ }
+AppenderAttachableImpl::~AppenderAttachableImpl() = default;
 
 
 

--- a/src/asyncappender.cxx
+++ b/src/asyncappender.cxx
@@ -62,7 +62,7 @@ QueueThread::QueueThread (AsyncAppenderPtr aai, thread::QueuePtr q)
 void
 QueueThread::run()
 {
-    typedef log4cplus::thread::Queue::queue_storage_type ev_buf_type;
+    using ev_buf_type = log4cplus::thread::Queue::queue_storage_type;
     ev_buf_type ev_buf;
 
     while (true)

--- a/src/asyncappender.cxx
+++ b/src/asyncappender.cxx
@@ -70,8 +70,8 @@ QueueThread::run()
         unsigned qflags = queue->get_events (&ev_buf);
         if (qflags & thread::Queue::EVENT)
         {
-            ev_buf_type::const_iterator const ev_buf_end = ev_buf.end ();
-            for (ev_buf_type::const_iterator it = ev_buf.begin ();
+            auto const ev_buf_end = ev_buf.end ();
+            for (auto it = ev_buf.begin ();
                 it != ev_buf_end; ++it)
                 appenders->appendLoopOnAppenders (*it);
         }

--- a/src/callbackappender.cxx
+++ b/src/callbackappender.cxx
@@ -32,8 +32,7 @@ namespace log4cplus
 {
 
 
-CallbackAppender::CallbackAppender()
-{ }
+CallbackAppender::CallbackAppender() = default;
 
 
 CallbackAppender::CallbackAppender(log4cplus_log_event_callback_t callback_,

--- a/src/clfsappender.cxx
+++ b/src/clfsappender.cxx
@@ -64,7 +64,7 @@ loglog_win32_error (tchar const * msg)
     helpers::getLogLog ().error (oss.str ());
 }
 
-}
+} // namespace
 
 
 struct CLFSAppender::Data

--- a/src/clfsappender.cxx
+++ b/src/clfsappender.cxx
@@ -71,13 +71,12 @@ struct CLFSAppender::Data
 {
     Data ()
         : log_handle (INVALID_HANDLE_VALUE)
-        , buffer (0)
         , buffer_size (0)
     { }
 
     tstring log_name;
     HANDLE log_handle;
-    void * buffer;
+    void * buffer{0};
     ULONG buffer_size;
 };
 

--- a/src/clfsappender.cxx
+++ b/src/clfsappender.cxx
@@ -76,7 +76,7 @@ struct CLFSAppender::Data
 
     tstring log_name;
     HANDLE log_handle;
-    void * buffer{0};
+    void * buffer{nullptr};
     ULONG buffer_size;
 };
 

--- a/src/clfsappender.cxx
+++ b/src/clfsappender.cxx
@@ -70,8 +70,7 @@ loglog_win32_error (tchar const * msg)
 struct CLFSAppender::Data
 {
     Data ()
-        : log_name ()
-        , log_handle (INVALID_HANDLE_VALUE)
+        : log_handle (INVALID_HANDLE_VALUE)
         , buffer (0)
         , buffer_size (0)
     { }
@@ -85,8 +84,7 @@ struct CLFSAppender::Data
 
 CLFSAppender::CLFSAppender (tstring const & logname, unsigned long logsize,
     unsigned long buffersize)
-    : Appender ()
-    , data (new Data)
+    : data (new Data)
 {
     init (logname, logsize, buffersize);
 }

--- a/src/clfsappender.cxx
+++ b/src/clfsappender.cxx
@@ -93,7 +93,7 @@ CLFSAppender::CLFSAppender (helpers::Properties const & props)
     : Appender (props)
     , data (new Data)
 {
-    tstring logname = props.getProperty (LOG4CPLUS_TEXT ("LogName"));
+    const tstring& logname = props.getProperty (LOG4CPLUS_TEXT ("LogName"));
 
     unsigned long logsize = CLFS_APPENDER_INITIAL_LOG_SIZE;
     props.getULong (logsize, LOG4CPLUS_TEXT ("LogSize"));

--- a/src/clfsappender.cxx
+++ b/src/clfsappender.cxx
@@ -72,7 +72,7 @@ struct CLFSAppender::Data
     Data ()
         : log_handle (INVALID_HANDLE_VALUE)
         , buffer_size (0)
-    { }
+    = default;
 
     tstring log_name;
     HANDLE log_handle;

--- a/src/clogger.cxx
+++ b/src/clogger.cxx
@@ -67,7 +67,7 @@ log4cplus_deinitialize(void * initializer_)
 
     try
     {
-        Initializer * initializer = static_cast<Initializer *>(initializer_);
+        auto * initializer = static_cast<Initializer *>(initializer_);
         delete initializer;
     }
     catch (std::exception const &)

--- a/src/clogger.cxx
+++ b/src/clogger.cxx
@@ -54,7 +54,7 @@ log4cplus_initialize(void)
     }
     catch (std::exception const &)
     {
-        return 0;
+        return nullptr;
     }
 }
 
@@ -287,7 +287,7 @@ log4cplus_logger_log(const log4cplus_char_t *name, loglevel_t ll,
             }
             while (retval == -1);
 
-            logger.forcedLog(ll, msg, 0, -1);
+            logger.forcedLog(ll, msg, nullptr, -1);
         }
 
         retval = 0;
@@ -313,7 +313,7 @@ log4cplus_logger_log_str(const log4cplus_char_t *name,
 
         if (logger.isEnabledFor(ll))
         {
-            logger.forcedLog(ll, msg, 0, -1);
+            logger.forcedLog(ll, msg, nullptr, -1);
         }
 
         retval = 0;
@@ -348,7 +348,7 @@ log4cplus_logger_force_log(const log4cplus_char_t *name, loglevel_t ll,
         }
         while (retval == -1);
 
-        logger.forcedLog(ll, msg, 0, -1);
+        logger.forcedLog(ll, msg, nullptr, -1);
 
         retval = 0;
     }
@@ -370,7 +370,7 @@ log4cplus_logger_force_log_str(const log4cplus_char_t *name, loglevel_t ll,
     try
     {
         Logger logger = name ? Logger::getInstance(name) : Logger::getRoot();
-        logger.forcedLog(ll, msg, 0, -1);
+        logger.forcedLog(ll, msg, nullptr, -1);
         retval = 0;
     }
     catch (std::exception const &)

--- a/src/clogger.cxx
+++ b/src/clogger.cxx
@@ -391,8 +391,7 @@ CustomLogLevelManager::CustomLogLevelManager ()
 { }
 
 
-CustomLogLevelManager::~CustomLogLevelManager ()
-{ }
+CustomLogLevelManager::~CustomLogLevelManager () = default;
 
 
 bool

--- a/src/clogger.cxx
+++ b/src/clogger.cxx
@@ -382,9 +382,7 @@ log4cplus_logger_force_log_str(const log4cplus_char_t *name, loglevel_t ll,
 }
 
 
-namespace log4cplus {
-
-namespace internal {
+namespace log4cplus::internal {
 
 CustomLogLevelManager::CustomLogLevelManager ()
     : pushed_methods (false)
@@ -472,8 +470,6 @@ CustomLogLevelManager::fromString (const log4cplus::tstring_view& nm) const
 
     return NOT_SET_LOG_LEVEL;
 }
-
-} // namespace internal
 
 } // namespace log4cplus
 

--- a/src/configurator.cxx
+++ b/src/configurator.cxx
@@ -250,9 +250,7 @@ PropertyConfigurator::init()
 }
 
 
-PropertyConfigurator::~PropertyConfigurator()
-{
-}
+PropertyConfigurator::~PropertyConfigurator() = default;
 
 
 
@@ -569,9 +567,7 @@ BasicConfigurator::BasicConfigurator(Hierarchy& hier, bool logToStdErr)
 
 
 
-BasicConfigurator::~BasicConfigurator()
-{
-}
+BasicConfigurator::~BasicConfigurator() = default;
 
 
 //////////////////////////////////////////////////////////////////////////////
@@ -610,8 +606,7 @@ public:
         updateLastModInfo();
     }
 
-    virtual ~ConfigurationWatchDogThread ()
-    { }
+    virtual ~ConfigurationWatchDogThread () = default;
 
     void terminate ()
     {

--- a/src/configurator.cxx
+++ b/src/configurator.cxx
@@ -353,7 +353,7 @@ PropertyConfigurator::replaceEnvironVariables()
     {
         changed = false;
         keys = properties.propertyNames();
-        for (std::vector<tstring>::const_iterator it = keys.begin();
+        for (auto it = keys.begin();
             it != keys.end(); ++it)
         {
             tstring const & key = *it;

--- a/src/configurator.cxx
+++ b/src/configurator.cxx
@@ -621,9 +621,9 @@ protected:
     void updateLastModInfo();
 
 private:
-    ConfigurationWatchDogThread (ConfigurationWatchDogThread const &);
+    ConfigurationWatchDogThread (ConfigurationWatchDogThread const &) = delete;
     ConfigurationWatchDogThread & operator = (
-        ConfigurationWatchDogThread const &);
+        ConfigurationWatchDogThread const &) = delete;
 
     unsigned int const waitMillis;
     thread::ManualResetEvent shouldTerminate;

--- a/src/configurator.cxx
+++ b/src/configurator.cxx
@@ -291,7 +291,7 @@ PropertyConfigurator::configure()
 
     unsigned int thread_pool_size;
     if (properties.getUInt (thread_pool_size, LOG4CPLUS_TEXT ("threadPoolSize")))
-        thread_pool_size = (std::min) (thread_pool_size, 1024u);
+        thread_pool_size = (std::min) (thread_pool_size, 1024U);
     else
         thread_pool_size = 4;
 

--- a/src/configurator.cxx
+++ b/src/configurator.cxx
@@ -351,10 +351,8 @@ PropertyConfigurator::replaceEnvironVariables()
     {
         changed = false;
         keys = properties.propertyNames();
-        for (auto it = keys.begin();
-            it != keys.end(); ++it)
+        for (auto & key : keys)
         {
-            tstring const & key = *it;
             val = properties.getProperty(key);
 
             subKey.clear ();

--- a/src/configurator.cxx
+++ b/src/configurator.cxx
@@ -604,7 +604,7 @@ public:
         updateLastModInfo();
     }
 
-    virtual ~ConfigurationWatchDogThread () = default;
+    ~ConfigurationWatchDogThread () override = default;
 
     void terminate ()
     {
@@ -613,9 +613,9 @@ public:
     }
 
 protected:
-    virtual void run();
-    virtual Logger getLogger(const tstring& name);
-    virtual void addAppender(Logger &logger, SharedAppenderPtr& appender);
+    void run() override;
+    Logger getLogger(const tstring& name) override;
+    void addAppender(Logger &logger, SharedAppenderPtr& appender) override;
 
     bool checkForFileModification();
     void updateLastModInfo();

--- a/src/connectorthread.cxx
+++ b/src/connectorthread.cxx
@@ -30,8 +30,7 @@
 namespace log4cplus { namespace helpers {
 
 
-IConnectorThreadClient::~IConnectorThreadClient ()
-{ }
+IConnectorThreadClient::~IConnectorThreadClient () = default;
 
 //
 //
@@ -44,8 +43,7 @@ ConnectorThread::ConnectorThread (
 { }
 
 
-ConnectorThread::~ConnectorThread ()
-{ }
+ConnectorThread::~ConnectorThread () = default;
 
 
 void

--- a/src/connectorthread.cxx
+++ b/src/connectorthread.cxx
@@ -27,7 +27,7 @@
 
 #if ! defined (LOG4CPLUS_SINGLE_THREADED)
 
-namespace log4cplus { namespace helpers {
+namespace log4cplus::helpers {
 
 
 IConnectorThreadClient::~IConnectorThreadClient () = default;
@@ -122,6 +122,6 @@ ConnectorThread::trigger ()
 }
 
 
-} } // namespace log4cplus { namespace helpers {
+} // namespace log4cplus::helpers
 
 #endif // ! defined (LOG4CPLUS_SINGLE_THREADED)

--- a/src/env.cxx
+++ b/src/env.cxx
@@ -58,7 +58,7 @@
 #include <memory>
 
 
-namespace log4cplus { namespace internal {
+namespace log4cplus::internal {
 
 #if defined(_WIN32)
 tstring const dir_sep(LOG4CPLUS_TEXT("\\"));
@@ -669,4 +669,4 @@ make_dirs (tstring const & file_path)
 }
 
 
-} } // namespace log4cplus { namespace internal {
+} // namespace log4cplus::internal

--- a/src/env.cxx
+++ b/src/env.cxx
@@ -209,8 +209,7 @@ namespace
 
 struct path_sep_comp
 {
-    path_sep_comp ()
-    { }
+    path_sep_comp () = default;
 
     bool
     operator () (tchar ch) const

--- a/src/factory.cxx
+++ b/src/factory.cxx
@@ -43,40 +43,30 @@ namespace log4cplus {
 
 namespace spi {
 
-BaseFactory::~BaseFactory()
-{ }
+BaseFactory::~BaseFactory() = default;
 
 
-AppenderFactory::AppenderFactory()
-{ }
+AppenderFactory::AppenderFactory() = default;
 
-AppenderFactory::~AppenderFactory()
-{ }
+AppenderFactory::~AppenderFactory() = default;
 
 
-LayoutFactory::LayoutFactory()
-{ }
+LayoutFactory::LayoutFactory() = default;
 
-LayoutFactory::~LayoutFactory()
-{ }
+LayoutFactory::~LayoutFactory() = default;
 
 
-FilterFactory::FilterFactory()
-{ }
+FilterFactory::FilterFactory() = default;
 
-FilterFactory::~FilterFactory()
-{ }
+FilterFactory::~FilterFactory() = default;
 
 
-LocaleFactory::LocaleFactory()
-{ }
+LocaleFactory::LocaleFactory() = default;
 
-LocaleFactory::~LocaleFactory()
-{ }
+LocaleFactory::~LocaleFactory() = default;
 
 
-LoggerFactory::~LoggerFactory()
-{ }
+LoggerFactory::~LoggerFactory() = default;
 
 
 namespace

--- a/src/factory.cxx
+++ b/src/factory.cxx
@@ -147,7 +147,7 @@ namespace
 template <typename Factory>
 struct DisableFactoryLocking
 {
-    typedef Factory factory_type;
+    using factory_type = Factory;
 
     explicit
     DisableFactoryLocking (factory_type & f)

--- a/src/fileappender.cxx
+++ b/src/fileappender.cxx
@@ -284,7 +284,7 @@ FileAppenderBase::init()
     }
 
     helpers::LockFileGuard guard;
-    if (useLockFile && ! lockFile.get ())
+    if (useLockFile && ! lockFile)
     {
         if (createDirs)
             internal::make_dirs (lockFileName);

--- a/src/fileinfo.cxx
+++ b/src/fileinfo.cxx
@@ -39,7 +39,7 @@
 #endif
 
 
-namespace log4cplus { namespace helpers {
+namespace log4cplus::helpers {
 
 
 int
@@ -69,4 +69,4 @@ getFileInfo (FileInfo * fi, tstring const & name)
     return 0;
 }
 
-} } // namespace log4cplus { namespace helpers {
+} // namespace log4cplus::helpers

--- a/src/filter.cxx
+++ b/src/filter.cxx
@@ -341,7 +341,7 @@ FilterResult MDCMatchFilter::decide(const InternalLoggingEvent& event) const
     if(neutralOnEmpty && (mdcKeyToMatch.empty() || mdcValueToMatch.empty()))
         return NEUTRAL;
 
-    const tstring mdcStr = event.getMDC(mdcKeyToMatch);
+    const tstring& mdcStr = event.getMDC(mdcKeyToMatch);
 
     if(neutralOnEmpty && mdcStr.empty())
         return NEUTRAL;

--- a/src/filter.cxx
+++ b/src/filter.cxx
@@ -33,7 +33,7 @@
 #endif
 
 
-namespace log4cplus { namespace spi {
+namespace log4cplus::spi {
 
 ///////////////////////////////////////////////////////////////////////////////
 // global methods
@@ -710,4 +710,4 @@ CATCH_TEST_CASE ("Filter", "[filter]")
 
 #endif
 
-} } // namespace log4cplus { namespace spi {
+} // namespace log4cplus::spi

--- a/src/filter.cxx
+++ b/src/filter.cxx
@@ -304,7 +304,7 @@ FilterResult NDCMatchFilter::decide(const InternalLoggingEvent& event) const
         return NEUTRAL;
     }
 
-    if(ndcStr.compare(ndcToMatch) == 0)
+    if(ndcStr == ndcToMatch)
         return (acceptOnMatch ? ACCEPT : DENY);
 
     return (acceptOnMatch ? DENY : ACCEPT);
@@ -346,7 +346,7 @@ FilterResult MDCMatchFilter::decide(const InternalLoggingEvent& event) const
     if(neutralOnEmpty && mdcStr.empty())
         return NEUTRAL;
 
-    if(mdcStr.compare(mdcValueToMatch) == 0)
+    if(mdcStr == mdcValueToMatch)
         return (acceptOnMatch ? ACCEPT : DENY);
 
     return (acceptOnMatch ? DENY : ACCEPT);

--- a/src/filter.cxx
+++ b/src/filter.cxx
@@ -61,14 +61,10 @@ checkFilter(const Filter* filter, const InternalLoggingEvent& event)
 // Filter implementation
 ///////////////////////////////////////////////////////////////////////////////
 
-Filter::Filter()
-{
-}
+Filter::Filter() = default;
 
 
-Filter::~Filter()
-{
-}
+Filter::~Filter() = default;
 
 
 void
@@ -86,8 +82,7 @@ Filter::appendFilter(FilterPtr filter)
 // DenyAllFilter implementation
 ///////////////////////////////////////////////////////////////////////////////
 
-DenyAllFilter::DenyAllFilter ()
-{ }
+DenyAllFilter::DenyAllFilter () = default;
 
 
 DenyAllFilter::DenyAllFilter (const helpers::Properties&)

--- a/src/global-init.cxx
+++ b/src/global-init.cxx
@@ -392,16 +392,13 @@ gft_scratch_pad::gft_scratch_pad ()
 { }
 
 
-gft_scratch_pad::~gft_scratch_pad ()
-{ }
+gft_scratch_pad::~gft_scratch_pad () = default;
 
 
-appender_sratch_pad::appender_sratch_pad ()
-{ }
+appender_sratch_pad::appender_sratch_pad () = default;
 
 
-appender_sratch_pad::~appender_sratch_pad ()
-{ }
+appender_sratch_pad::~appender_sratch_pad () = default;
 
 
 per_thread_data::per_thread_data ()

--- a/src/global-init.cxx
+++ b/src/global-init.cxx
@@ -468,7 +468,7 @@ void
 #endif
 ptd_cleanup_func (void * arg)
 {
-    internal::per_thread_data * const arg_ptd
+    auto * const arg_ptd
         = static_cast<internal::per_thread_data *>(arg);
     internal::per_thread_data * const ptd = internal::get_ptd (false);
     (void) ptd;

--- a/src/hierarchylocker.cxx
+++ b/src/hierarchylocker.cxx
@@ -35,8 +35,7 @@ namespace log4cplus
 
 HierarchyLocker::HierarchyLocker(Hierarchy& _h)
 : h(_h),
-  hierarchyLocker(h.hashtable_mutex),
-  loggerList()
+  hierarchyLocker(h.hashtable_mutex)
 {
     // Get a copy of all of the Hierarchy's Loggers (except the Root Logger)
     h.initializeLoggerList(loggerList);

--- a/src/hierarchylocker.cxx
+++ b/src/hierarchylocker.cxx
@@ -53,7 +53,7 @@ HierarchyLocker::HierarchyLocker(Hierarchy& _h)
         helpers::getLogLog().error(
             LOG4CPLUS_TEXT("HierarchyLocker::ctor()")
             LOG4CPLUS_TEXT("- An error occurred while locking"));
-        LoggerList::iterator range_end = it;
+        auto range_end = it;
         for (it = loggerList.begin (); it != range_end; ++it)
             it->value->appender_list_mutex.unlock ();
         throw;

--- a/src/layout.cxx
+++ b/src/layout.cxx
@@ -96,8 +96,7 @@ SimpleLayout::formatAndAppend(log4cplus::tostream& output,
 
   TTCCLayout::TTCCLayout(bool use_gmtime_, bool thread_printing_,
       bool category_prefixing_, bool context_printing_)
-    : dateFormat()
-    , use_gmtime(use_gmtime_)
+    : use_gmtime(use_gmtime_)
     , thread_printing (thread_printing_)
     , category_prefixing (category_prefixing_)
     , context_printing (context_printing_)

--- a/src/layout.cxx
+++ b/src/layout.cxx
@@ -57,16 +57,14 @@ Layout::Layout (const log4cplus::helpers::Properties&)
 { }
 
 
-Layout::~Layout()
-{ }
+Layout::~Layout() = default;
 
 
 ///////////////////////////////////////////////////////////////////////////////
 // log4cplus::SimpleLayout public methods
 ///////////////////////////////////////////////////////////////////////////////
 
-SimpleLayout::SimpleLayout ()
-{ }
+SimpleLayout::SimpleLayout () = default;
 
 
 SimpleLayout::SimpleLayout (const helpers::Properties& properties)
@@ -74,8 +72,7 @@ SimpleLayout::SimpleLayout (const helpers::Properties& properties)
 { }
 
 
-SimpleLayout::~SimpleLayout()
-{ }
+SimpleLayout::~SimpleLayout() = default;
 
 
 void
@@ -116,8 +113,7 @@ TTCCLayout::TTCCLayout(const log4cplus::helpers::Properties& properties)
 }
 
 
-TTCCLayout::~TTCCLayout()
-{ }
+TTCCLayout::~TTCCLayout() = default;
 
 
 

--- a/src/lockfile.cxx
+++ b/src/lockfile.cxx
@@ -81,7 +81,7 @@
 #error "no usable file locking"
 #endif
 
-namespace log4cplus { namespace helpers {
+namespace log4cplus::helpers {
 
 
 #if defined (_WIN32)
@@ -375,4 +375,4 @@ void LockFile::unlock () const
 
 
 
-} } // namespace log4cplus { namespace helpers {
+} // namespace log4cplus::helpers

--- a/src/log4judpappender.cxx
+++ b/src/log4judpappender.cxx
@@ -58,9 +58,8 @@ static
 void
 output_xml_escaped (tostream & os, tstring const & str)
 {
-    for (tstring::const_iterator it = str.begin (); it != str.end (); ++it)
+    for (char ch : str)
     {
-        tchar const & ch = *it;
         switch (ch)
         {
         case LOG4CPLUS_TEXT ('<'):

--- a/src/log4judpappender.cxx
+++ b/src/log4judpappender.cxx
@@ -107,7 +107,7 @@ output_xml_escaped (tostream & os, tstring const & str)
 //! Helper manipulator like class for escaped XML output.
 struct outputXMLEscaped
 {
-    outputXMLEscaped (tstring const & s)
+    explicit outputXMLEscaped (tstring const & s)
         : str (s)
     { }
 

--- a/src/logger.cxx
+++ b/src/logger.cxx
@@ -104,8 +104,7 @@ Logger::shutdown ()
 // Logger ctors and dtor
 //////////////////////////////////////////////////////////////////////////////
 
-Logger::Logger () LOG4CPLUS_NOEXCEPT
-{ }
+Logger::Logger () LOG4CPLUS_NOEXCEPT = default;
 
 
 Logger::Logger (spi::LoggerImpl * ptr) LOG4CPLUS_NOEXCEPT

--- a/src/loggerimpl.cxx
+++ b/src/loggerimpl.cxx
@@ -43,9 +43,7 @@ LoggerImpl::LoggerImpl(const log4cplus::tstring_view& name_, Hierarchy& h)
 }
 
 
-LoggerImpl::~LoggerImpl()
-{
-}
+LoggerImpl::~LoggerImpl() = default;
 
 
 //////////////////////////////////////////////////////////////////////////////

--- a/src/loggerimpl.cxx
+++ b/src/loggerimpl.cxx
@@ -28,7 +28,7 @@
 #include <log4cplus/thread/syncprims-pub-impl.h>
 
 
-namespace log4cplus { namespace spi {
+namespace log4cplus::spi {
 
 //////////////////////////////////////////////////////////////////////////////
 // Logger Constructors and Destructor
@@ -177,4 +177,4 @@ LoggerImpl::forcedLog(spi::InternalLoggingEvent const & ev)
 }
 
 
-} } // namespace log4cplus { namespace spi {
+} // namespace log4cplus::spi

--- a/src/loggingevent.cxx
+++ b/src/loggingevent.cxx
@@ -23,7 +23,7 @@
 #include <algorithm>
 
 
-namespace log4cplus {  namespace spi {
+namespace log4cplus::spi {
 
 
 static const int LOG4CPLUS_DEFAULT_TYPE = 1;
@@ -298,4 +298,4 @@ InternalLoggingEvent::swap (InternalLoggingEvent & other)
 }
 
 
-} } // namespace log4cplus {  namespace spi {
+} // namespace log4cplus::spi

--- a/src/loggingevent.cxx
+++ b/src/loggingevent.cxx
@@ -40,9 +40,6 @@ InternalLoggingEvent::InternalLoggingEvent(
     : message(message_)
     , loggerName(logger)
     , ll(loglevel)
-    , ndc()
-    , mdc()
-    , thread()
     , timestamp(log4cplus::helpers::now ())
     , file(filename
         ? LOG4CPLUS_C_STR_TO_TSTRING(filename)
@@ -121,7 +118,6 @@ InternalLoggingEvent::InternalLoggingEvent(
 
 InternalLoggingEvent::InternalLoggingEvent ()
     : ll (NOT_SET_LOG_LEVEL)
-    , function ()
     , line (0)
     , threadCached(false)
     , thread2Cached(false)

--- a/src/loggingevent.cxx
+++ b/src/loggingevent.cxx
@@ -147,9 +147,7 @@ InternalLoggingEvent::InternalLoggingEvent(
 }
 
 
-InternalLoggingEvent::~InternalLoggingEvent()
-{
-}
+InternalLoggingEvent::~InternalLoggingEvent() = default;
 
 
 

--- a/src/loggingevent.cxx
+++ b/src/loggingevent.cxx
@@ -255,7 +255,7 @@ tstring const &
 InternalLoggingEvent::getMDC (tstring const & key) const
 {
     MappedDiagnosticContextMap const & mdc_ = getMDCCopy ();
-    MappedDiagnosticContextMap::const_iterator it = mdc_.find (key);
+    auto it = mdc_.find (key);
     if (it != mdc_.end ())
         return it->second;
     else

--- a/src/loggingmacros.cxx
+++ b/src/loggingmacros.cxx
@@ -25,7 +25,7 @@
 #include <log4cplus/loggingmacros.h>
 
 
-namespace log4cplus { namespace detail {
+namespace log4cplus::detail {
 
 
 //! Helper stream to get the defaults from.
@@ -97,4 +97,4 @@ macro_forced_log (log4cplus::Logger const & logger,
 }
 
 
-} } // namespace log4cplus { namespace detail {
+} // namespace log4cplus::detail

--- a/src/loglevel.cxx
+++ b/src/loglevel.cxx
@@ -58,11 +58,10 @@ class LOG4CPLUS_PRIVATE DefaultLogLevelTranslator
 public:
     DefaultLogLevelTranslator () = default;
 
-    virtual ~DefaultLogLevelTranslator () = default;
+    ~DefaultLogLevelTranslator () override = default;
 
-    virtual
     log4cplus::tstring const &
-    toString (LogLevel ll) const
+    toString (LogLevel ll) const override
     {
         switch(ll) {
         case OFF_LOG_LEVEL:     return OFF_STRING;
@@ -79,9 +78,8 @@ public:
         return internal::empty_str;
     }
 
-    virtual
     LogLevel
-    fromString (const log4cplus::tstring_view& s) const
+    fromString (const log4cplus::tstring_view& s) const override
     {
         // Since C++11, accessing str[0] is always safe as it returns '\0' for
         // empty string.
@@ -121,11 +119,10 @@ public:
         , name (name_)
     { }
 
-    virtual ~SingleLogLevelTranslator () = default;
+    ~SingleLogLevelTranslator () override = default;
 
-    virtual
     log4cplus::tstring const &
-    toString (LogLevel ll) const
+    toString (LogLevel ll) const override
     {
         if (ll == log_level)
             return name;
@@ -133,9 +130,8 @@ public:
             return internal::empty_str;
     }
 
-    virtual
     LogLevel
-    fromString (const log4cplus::tstring_view& s) const
+    fromString (const log4cplus::tstring_view& s) const override
     {
         if (s == name)
             return log_level;

--- a/src/loglevel.cxx
+++ b/src/loglevel.cxx
@@ -30,11 +30,9 @@ namespace log4cplus
 {
 
 
-LogLevelTranslator::LogLevelTranslator ()
-{ }
+LogLevelTranslator::LogLevelTranslator () = default;
 
-LogLevelTranslator::~LogLevelTranslator ()
-{ }
+LogLevelTranslator::~LogLevelTranslator () = default;
 
 
 
@@ -58,11 +56,9 @@ class LOG4CPLUS_PRIVATE DefaultLogLevelTranslator
     : virtual public LogLevelTranslator
 {
 public:
-    DefaultLogLevelTranslator ()
-    { }
+    DefaultLogLevelTranslator () = default;
 
-    virtual ~DefaultLogLevelTranslator ()
-    { }
+    virtual ~DefaultLogLevelTranslator () = default;
 
     virtual
     log4cplus::tstring const &
@@ -125,8 +121,7 @@ public:
         , name (name_)
     { }
 
-    virtual ~SingleLogLevelTranslator ()
-    { }
+    virtual ~SingleLogLevelTranslator () = default;
 
     virtual
     log4cplus::tstring const &
@@ -167,8 +162,7 @@ LogLevelManager::LogLevelManager()
 }
 
 
-LogLevelManager::~LogLevelManager()
-{ }
+LogLevelManager::~LogLevelManager() = default;
 
 
 

--- a/src/loglog.cxx
+++ b/src/loglog.cxx
@@ -53,8 +53,7 @@ LogLog::LogLog()
 { }
 
 
-LogLog::~LogLog()
-{ }
+LogLog::~LogLog() = default;
 
 
 void

--- a/src/loglog.cxx
+++ b/src/loglog.cxx
@@ -28,7 +28,7 @@
 #include <stdexcept>
 
 
-namespace log4cplus { namespace helpers {
+namespace log4cplus::helpers {
 
 namespace
 {
@@ -184,4 +184,4 @@ LogLog::logging_worker (tostream & os, bool (LogLog:: * cond) () const,
 }
 
 
-} } // namespace log4cplus { namespace helpers {
+} // namespace log4cplus::helpers

--- a/src/mdc.cxx
+++ b/src/mdc.cxx
@@ -70,7 +70,7 @@ MDC::get (tstring * value, tstring const & key) const
     assert (value);
 
     MappedDiagnosticContextMap * const dc = getPtr ();
-    MappedDiagnosticContextMap::const_iterator it = dc->find (key);
+    auto it = dc->find (key);
     if (it != dc->end ())
     {
         *value = it->second;

--- a/src/mdc.cxx
+++ b/src/mdc.cxx
@@ -33,12 +33,10 @@ namespace log4cplus
 {
 
 
-MDC::MDC ()
-{ }
+MDC::MDC () = default;
 
 
-MDC::~MDC ()
-{ }
+MDC::~MDC () = default;
 
 
 MappedDiagnosticContextMap *

--- a/src/msttsappender.cxx
+++ b/src/msttsappender.cxx
@@ -177,8 +177,6 @@ struct MSTTSAppender::Data
 {
     Data ()
         : ispvoice (0)
-        , async (false)
-        , speak_punc (false)
     { }
 
     ~Data ()
@@ -189,8 +187,8 @@ struct MSTTSAppender::Data
 
     helpers::SharedObjectPtr<SpeechObjectThread> speech_thread;
     ISpVoice * ispvoice;
-    bool async;
-    bool speak_punc;
+    bool async{false};
+    bool speak_punc{false};
 };
 
 

--- a/src/msttsappender.cxx
+++ b/src/msttsappender.cxx
@@ -108,7 +108,7 @@ public:
     }
 
 
-    ~SpeechObjectThread ()
+    ~SpeechObjectThread () override
     {
         if (! CloseHandle (terminate_ev))
             loglog_win32_error (
@@ -116,9 +116,8 @@ public:
     }
 
 
-    virtual
     void
-    run ()
+    run () override
     {
         COMInitializer com_init (COINIT_MULTITHREADED);
 

--- a/src/msttsappender.cxx
+++ b/src/msttsappender.cxx
@@ -97,7 +97,7 @@ class SpeechObjectThread
     : public virtual log4cplus::thread::AbstractThread
 {
 public:
-    SpeechObjectThread (ISpVoice * & ispvoice_ref)
+    explicit SpeechObjectThread (ISpVoice * & ispvoice_ref)
         : ispvoice (ispvoice_ref)
     {
         terminate_ev = CreateEvent (0, true, false, 0);

--- a/src/msttsappender.cxx
+++ b/src/msttsappender.cxx
@@ -220,7 +220,7 @@ MSTTSAppender::MSTTSAppender (helpers::Properties const & props)
     speak_punc = props.getBool (speak_punc, LOG4CPLUS_TEXT ("SpeakPunc"))
         && speak_punc;
 
-    init (has_rate ? &rate : 0, has_volume ? &volume : 0, speak_punc, async);
+    init (has_rate ? &rate : nullptr, has_volume ? &volume : nullptr, speak_punc, async);
 }
 
 

--- a/src/msttsappender.cxx
+++ b/src/msttsappender.cxx
@@ -195,8 +195,7 @@ struct MSTTSAppender::Data
 
 
 MSTTSAppender::MSTTSAppender ()
-    : Appender ()
-    , data (new Data)
+    : data (new Data)
 {
     init ();
 }

--- a/src/msttsappender.cxx
+++ b/src/msttsappender.cxx
@@ -177,7 +177,7 @@ struct MSTTSAppender::Data
 {
     Data ()
         : ispvoice (0)
-    { }
+    = default;
 
     ~Data ()
     {

--- a/src/ndc.cxx
+++ b/src/ndc.cxx
@@ -93,10 +93,7 @@ DiagnosticContext::DiagnosticContext(tchar const * message_)
 }
 
 
-DiagnosticContext::DiagnosticContext (DiagnosticContext const & other)
-    : message (other.message)
-    , fullMessage (other.fullMessage)
-{ }
+DiagnosticContext::DiagnosticContext (DiagnosticContext const & other) = default;
 
 
 DiagnosticContext & DiagnosticContext::operator = (
@@ -134,11 +131,11 @@ DiagnosticContext::swap (DiagnosticContext & other)
 ///////////////////////////////////////////////////////////////////////////////
 
 NDC::NDC()
-{ }
+= default;
 
 
 NDC::~NDC()
-{ }
+= default;
 
 
 

--- a/src/ndc.cxx
+++ b/src/ndc.cxx
@@ -66,7 +66,6 @@ init_full_message (log4cplus::tstring & fullMessage,
 DiagnosticContext::DiagnosticContext(const log4cplus::tstring& message_,
                                      DiagnosticContext const * parent)
     : message(message_)
-    , fullMessage()
 {
     init_full_message (fullMessage, message, parent);
 }
@@ -75,7 +74,6 @@ DiagnosticContext::DiagnosticContext(const log4cplus::tstring& message_,
 DiagnosticContext::DiagnosticContext(tchar const * message_,
                                      DiagnosticContext const * parent)
     : message(message_)
-    , fullMessage()
 {
     init_full_message (fullMessage, message, parent);
 }

--- a/src/nullappender.cxx
+++ b/src/nullappender.cxx
@@ -30,9 +30,7 @@ namespace log4cplus
 // NullAppender ctors and dtor
 ///////////////////////////////////////////////////////////////////////////////
 
-NullAppender::NullAppender()
-{
-}
+NullAppender::NullAppender() = default;
 
 
 NullAppender::NullAppender(const helpers::Properties& properties)

--- a/src/objectregistry.cxx
+++ b/src/objectregistry.cxx
@@ -35,8 +35,7 @@ ObjectRegistryBase::ObjectRegistryBase()
 { }
 
 
-ObjectRegistryBase::~ObjectRegistryBase()
-{ }
+ObjectRegistryBase::~ObjectRegistryBase() = default;
 
 
 

--- a/src/objectregistry.cxx
+++ b/src/objectregistry.cxx
@@ -100,7 +100,7 @@ ObjectRegistryBase::getVal(const tstring& name) const
 {
     thread::MutexGuard guard (mutex);
 
-    ObjectMap::const_iterator it (data.find (name));
+    auto it (data.find (name));
     if (it != data.end ())
         return it->second;
     else

--- a/src/objectregistry.cxx
+++ b/src/objectregistry.cxx
@@ -23,7 +23,7 @@
 #include <log4cplus/thread/threads.h>
 
 
-namespace log4cplus { namespace spi {
+namespace log4cplus::spi {
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -126,4 +126,4 @@ ObjectRegistryBase::_enableLocking (bool enable)
 }
 
 
-} } // namespace log4cplus { namespace spi {
+} // namespace log4cplus::spi

--- a/src/patternlayout.cxx
+++ b/src/patternlayout.cxx
@@ -391,7 +391,6 @@ PatternConverter::formatAndAppend(
 
 LiteralPatternConverter::LiteralPatternConverter()
     : PatternConverter(FormattingInfo())
-    , str()
 { }
 
 

--- a/src/patternlayout.cxx
+++ b/src/patternlayout.cxx
@@ -221,7 +221,7 @@ private:
 //! This pattern is used to format miliseconds since process start.
 class RelativeTimestampConverter: public PatternConverter {
 public:
-    RelativeTimestampConverter(const FormattingInfo& info);
+    explicit RelativeTimestampConverter(const FormattingInfo& info);
     void convert(tstring & result,
         const spi::InternalLoggingEvent& event) override;
 };

--- a/src/patternlayout.cxx
+++ b/src/patternlayout.cxx
@@ -122,8 +122,8 @@ class LiteralPatternConverter : public PatternConverter
 public:
     LiteralPatternConverter();
     explicit LiteralPatternConverter(const tstring& str);
-    virtual void convert(tstring & result,
-        const spi::InternalLoggingEvent&)
+    void convert(tstring & result,
+        const spi::InternalLoggingEvent&) override
     {
         result = str;
     }
@@ -154,8 +154,8 @@ public:
                 FULL_LOCATION_CONVERTER,
                 FUNCTION_CONVERTER };
     BasicPatternConverter(const FormattingInfo& info, Type type);
-    virtual void convert(tstring & result,
-        const spi::InternalLoggingEvent& event);
+    void convert(tstring & result,
+        const spi::InternalLoggingEvent& event) override;
 
 private:
   // Disable copy
@@ -175,8 +175,8 @@ private:
 class LoggerPatternConverter : public PatternConverter {
 public:
     LoggerPatternConverter(const FormattingInfo& info, int precision);
-    virtual void convert(tstring & result,
-        const spi::InternalLoggingEvent& event);
+    void convert(tstring & result,
+        const spi::InternalLoggingEvent& event) override;
 
 private:
     int precision;
@@ -194,8 +194,8 @@ public:
     DatePatternConverter(const FormattingInfo& info,
                          const tstring& pattern,
                          bool use_gmtime);
-    virtual void convert(tstring & result,
-        const spi::InternalLoggingEvent& event);
+    void convert(tstring & result,
+        const spi::InternalLoggingEvent& event) override;
 
 private:
     bool use_gmtime;
@@ -210,8 +210,8 @@ class EnvPatternConverter : public PatternConverter {
 public:
     EnvPatternConverter(const FormattingInfo& info,
                         const log4cplus::tstring& env);
-    virtual void convert(tstring & result,
-        const spi::InternalLoggingEvent& event);
+    void convert(tstring & result,
+        const spi::InternalLoggingEvent& event) override;
 
 private:
     log4cplus::tstring envKey;
@@ -222,8 +222,8 @@ private:
 class RelativeTimestampConverter: public PatternConverter {
 public:
     RelativeTimestampConverter(const FormattingInfo& info);
-    virtual void convert(tstring & result,
-        const spi::InternalLoggingEvent& event);
+    void convert(tstring & result,
+        const spi::InternalLoggingEvent& event) override;
 };
 
 
@@ -233,8 +233,8 @@ public:
 class HostnamePatternConverter : public PatternConverter {
 public:
     HostnamePatternConverter(const FormattingInfo& info, bool fqdn);
-    virtual void convert(tstring & result,
-        const spi::InternalLoggingEvent& event);
+    void convert(tstring & result,
+        const spi::InternalLoggingEvent& event) override;
 
 private:
     tstring hostname_;
@@ -251,8 +251,8 @@ class MDCPatternConverter
 {
 public:
     MDCPatternConverter(const FormattingInfo& info, tstring const & k);
-    virtual void convert(tstring & result,
-        const spi::InternalLoggingEvent& event);
+    void convert(tstring & result,
+        const spi::InternalLoggingEvent& event) override;
 
 private:
     tstring key;
@@ -267,8 +267,8 @@ private:
 class NDCPatternConverter : public PatternConverter {
 public:
     NDCPatternConverter(const FormattingInfo& info, int precision);
-    virtual void convert(tstring & result,
-        const spi::InternalLoggingEvent& event);
+    void convert(tstring & result,
+        const spi::InternalLoggingEvent& event) override;
 
 private:
     int precision;

--- a/src/patternlayout.cxx
+++ b/src/patternlayout.cxx
@@ -111,8 +111,7 @@ private:
 };
 
 
-typedef std::vector<std::unique_ptr<pattern::PatternConverter> >
-PatternConverterList;
+using PatternConverterList = std::vector<std::unique_ptr<pattern::PatternConverter> >;
 
 
 /**
@@ -1036,7 +1035,7 @@ PatternParser::finalizeConverter(tchar c)
 } // namespace pattern
 
 
-typedef pattern::PatternConverterList PatternConverterList;
+using PatternConverterList = pattern::PatternConverterList;
 
 
 ////////////////////////////////////////////////

--- a/src/patternlayout.cxx
+++ b/src/patternlayout.cxx
@@ -159,8 +159,8 @@ public:
 
 private:
   // Disable copy
-    BasicPatternConverter(const BasicPatternConverter&);
-    BasicPatternConverter& operator=(BasicPatternConverter&);
+    BasicPatternConverter(const BasicPatternConverter&) = delete;
+    BasicPatternConverter& operator=(BasicPatternConverter&) = delete;
 
     LogLevelManager& llmCache;
     Type type;

--- a/src/patternlayout.cxx
+++ b/src/patternlayout.cxx
@@ -96,7 +96,7 @@ class PatternConverter
 {
 public:
     explicit PatternConverter(const FormattingInfo& info);
-    virtual ~PatternConverter() {}
+    virtual ~PatternConverter() = default;
     void formatAndAppend(tostream& output,
         const spi::InternalLoggingEvent& event);
 
@@ -1110,8 +1110,7 @@ PatternLayout::init(const tstring& pattern_, unsigned ndcMaxDepth)
 
 
 
-PatternLayout::~PatternLayout()
-{ }
+PatternLayout::~PatternLayout() = default;
 
 
 

--- a/src/pointer.cxx
+++ b/src/pointer.cxx
@@ -50,7 +50,7 @@ SharedObject::addReference() const LOG4CPLUS_NOEXCEPT
     ++count__;
 
 #else
-    std::atomic_fetch_add_explicit (&count__, 1u,
+    std::atomic_fetch_add_explicit (&count__, 1U,
         std::memory_order_relaxed);
 
 #endif
@@ -67,7 +67,7 @@ SharedObject::removeReference() const
     destroy = --count__ == 0;
 
 #else
-    destroy = std::atomic_fetch_sub_explicit (&count__, 1u,
+    destroy = std::atomic_fetch_sub_explicit (&count__, 1U,
         std::memory_order_release) == 1;
     if (LOG4CPLUS_UNLIKELY (destroy))
         std::atomic_thread_fence (std::memory_order_acquire);

--- a/src/pointer.cxx
+++ b/src/pointer.cxx
@@ -25,7 +25,7 @@
 #include <cassert>
 
 
-namespace log4cplus { namespace helpers {
+namespace log4cplus::helpers {
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -78,4 +78,4 @@ SharedObject::removeReference() const
 }
 
 
-} } // namespace log4cplus { namespace helpers
+} // namespace log4cplus::helpers

--- a/src/property.cxx
+++ b/src/property.cxx
@@ -47,7 +47,7 @@
 #endif
 
 
-namespace log4cplus { namespace helpers {
+namespace log4cplus::helpers {
 
 
 const tchar Properties::PROPERTIES_COMMENT_CHAR = LOG4CPLUS_TEXT('#');
@@ -536,4 +536,4 @@ CATCH_TEST_CASE ("Properties", "[properties]")
 #endif
 
 
-} } // namespace log4cplus { namespace helpers {
+} // namespace log4cplus::helpers

--- a/src/property.cxx
+++ b/src/property.cxx
@@ -321,7 +321,7 @@ Properties::getProperty(tchar const * key) const
 tstring
 Properties::getProperty(const tstring& key, const tstring& defaultVal) const
 {
-    StringMap::const_iterator it (data.find (key));
+    auto it (data.find (key));
     if (it == data.end ())
         return defaultVal;
     else
@@ -417,7 +417,7 @@ bool
 Properties::getString (log4cplus::tstring & val, log4cplus::tstring const & key)
     const
 {
-    StringMap::const_iterator it (data.find (key));
+    auto it (data.find (key));
     if (it == data.end ())
         return false;
 
@@ -430,7 +430,7 @@ template <typename StringType>
 log4cplus::tstring const &
 Properties::get_property_worker (StringType const & key) const
 {
-    StringMap::const_iterator it (data.find (key));
+    auto it (data.find (key));
     if (it == data.end ())
         return log4cplus::internal::empty_str;
     else

--- a/src/property.cxx
+++ b/src/property.cxx
@@ -279,9 +279,7 @@ Properties::init(tistream& input)
 
 
 
-Properties::~Properties()
-{
-}
+Properties::~Properties() = default;
 
 
 

--- a/src/queue.cxx
+++ b/src/queue.cxx
@@ -36,8 +36,7 @@ namespace log4cplus { namespace thread {
 
 
 Queue::Queue (unsigned len)
-    : mutex ()
-    , ev_consumer (false)
+    : ev_consumer (false)
     , sem (len, len)
     , flags (DRAIN)
 { }

--- a/src/queue.cxx
+++ b/src/queue.cxx
@@ -42,8 +42,7 @@ Queue::Queue (unsigned len)
 { }
 
 
-Queue::~Queue ()
-{ }
+Queue::~Queue () = default;
 
 
 Queue::flags_type

--- a/src/queue.cxx
+++ b/src/queue.cxx
@@ -32,7 +32,7 @@
 #include <iterator>
 
 
-namespace log4cplus { namespace thread {
+namespace log4cplus::thread {
 
 
 Queue::Queue (unsigned len)
@@ -186,7 +186,7 @@ Queue::get_events (queue_storage_type * buf)
 }
 
 
-} } // namespace log4cplus { namespace thread {
+} // namespace log4cplus::thread
 
 
 #endif // LOG4CPLUS_SINGLE_THREADED

--- a/src/rootlogger.cxx
+++ b/src/rootlogger.cxx
@@ -23,7 +23,7 @@
 #include <log4cplus/thread/syncprims-pub-impl.h>
 
 
-namespace log4cplus { namespace spi {
+namespace log4cplus::spi {
 
 
 //////////////////////////////////////////////////////////////////////////////
@@ -62,4 +62,4 @@ RootLogger::setLogLevel(LogLevel loglevel)
 }
 
 
-} } // namespace log4cplus { namespace spi {
+} // namespace log4cplus::spi

--- a/src/snprintf.cxx
+++ b/src/snprintf.cxx
@@ -44,7 +44,7 @@
 #endif
 
 
-namespace log4cplus { namespace helpers {
+namespace log4cplus::helpers {
 
 
 std::size_t const START_BUF_SIZE = 512;
@@ -162,7 +162,7 @@ vsntprintf (tchar * dest, std::size_t dest_size, tchar const * fmt,
 #endif
 
 
-}
+} // namespace
 
 
 snprintf_buf::snprintf_buf ()
@@ -285,4 +285,4 @@ CATCH_TEST_CASE ("snprintf_buf", "[snprintf_buf]")
 #endif
 
 
-} } // namespace log4cplus { namespace helpers
+} // namespace log4cplus::helpers

--- a/src/socket-unix.cxx
+++ b/src/socket-unix.cxx
@@ -255,14 +255,14 @@ namespace
 template <typename T, typename U>
 struct socklen_var
 {
-    typedef T type;
+    using type = T;
 };
 
 
 template <typename U>
 struct socklen_var<void, U>
 {
-    typedef U type;
+    using type = U;
 };
 
 

--- a/src/socket-unix.cxx
+++ b/src/socket-unix.cxx
@@ -73,7 +73,7 @@
 #endif
 
 
-namespace log4cplus { namespace helpers {
+namespace log4cplus::helpers {
 
 // from lockfile.cxx
 LOG4CPLUS_PRIVATE bool trySetCloseOnExec (int fd);
@@ -676,6 +676,6 @@ ServerSocket::~ServerSocket()
         ::close (interruptHandles[1]);
 }
 
-} } // namespace log4cplus
+} // namespace log4cplus
 
 #endif // LOG4CPLUS_USE_BSD_SOCKETS

--- a/src/socket-unix.cxx
+++ b/src/socket-unix.cxx
@@ -278,8 +278,8 @@ accept_wrap (
 {
     typedef typename socklen_var<accept_socklen_type, socklen_t>::type
         socklen_var_type;
-    socklen_var_type l = static_cast<socklen_var_type>(*len);
-    SOCKET_TYPE result
+    auto l = static_cast<socklen_var_type>(*len);
+    auto result
         = static_cast<SOCKET_TYPE>(
             accept_func (sock, sa,
                 reinterpret_cast<accept_socklen_type *>(&l)));
@@ -298,8 +298,8 @@ accept_wrap (
 {
     typedef typename socklen_var<accept_socklen_type, socklen_t>::type
         socklen_var_type;
-    socklen_var_type l = static_cast<socklen_var_type>(*len);
-    SOCKET_TYPE result
+    auto l = static_cast<socklen_var_type>(*len);
+    auto result
         = static_cast<SOCKET_TYPE>(
             accept_func (sock, sa,
                 reinterpret_cast<accept_socklen_type *>(&l),

--- a/src/socket.cxx
+++ b/src/socket.cxx
@@ -157,8 +157,7 @@ Socket::Socket (Socket && other) LOG4CPLUS_NOEXCEPT
 { }
 
 
-Socket::~Socket()
-{ }
+Socket::~Socket() = default;
 
 
 Socket &

--- a/src/socket.cxx
+++ b/src/socket.cxx
@@ -23,7 +23,7 @@
 #include <log4cplus/internal/internal.h>
 
 
-namespace log4cplus { namespace helpers {
+namespace log4cplus::helpers {
 
 
 extern LOG4CPLUS_EXPORT SOCKET_TYPE const INVALID_SOCKET_VALUE
@@ -262,4 +262,4 @@ openSocket(unsigned short port, bool udp, bool ipv6, SocketState& state)
 }
 
 
-} } // namespace log4cplus { namespace helpers {
+} // namespace log4cplus::helpers

--- a/src/socketbuffer.cxx
+++ b/src/socketbuffer.cxx
@@ -80,7 +80,7 @@ SocketBuffer::readByte()
         return 0;
     }
 
-    unsigned char ret = static_cast<unsigned char>(buffer[pos]);
+    auto ret = static_cast<unsigned char>(buffer[pos]);
     pos += sizeof(unsigned char);
 
     return ret;

--- a/src/socketbuffer.cxx
+++ b/src/socketbuffer.cxx
@@ -42,7 +42,7 @@
 #endif
 
 
-namespace log4cplus { namespace helpers {
+namespace log4cplus::helpers {
 
 
 //////////////////////////////////////////////////////////////////////////////
@@ -325,4 +325,4 @@ CATCH_TEST_CASE ("SocketBuffer", "[sockets]")
 #endif
 
 
-} } // namespace log4cplus { namespace helpers {
+} // namespace log4cplus::helpers

--- a/src/stringhelper-clocale.cxx
+++ b/src/stringhelper-clocale.cxx
@@ -31,10 +31,7 @@
 #include <vector>
 
 
-namespace log4cplus
-{
-
-namespace helpers
+namespace log4cplus::helpers
 {
 
 
@@ -165,7 +162,5 @@ towstring (char const * src)
 }
 
 #endif // LOG4CPLUS_WORKING_C_LOCALE
-
-} // namespace helpers
 
 } // namespace log4cplus

--- a/src/stringhelper-cxxlocale.cxx
+++ b/src/stringhelper-cxxlocale.cxx
@@ -36,10 +36,7 @@
 #include <vector>
 
 
-namespace log4cplus
-{
-
-namespace helpers
+namespace log4cplus::helpers
 {
 
 void clear_mbstate (std::mbstate_t &);
@@ -242,7 +239,5 @@ tostring(wchar_t const * src)
 
 
 #endif // LOG4CPLUS_WORKING_LOCALE
-
-} // namespace helpers
 
 } // namespace log4cplus

--- a/src/stringhelper.cxx
+++ b/src/stringhelper.cxx
@@ -36,15 +36,10 @@
 #endif
 
 
-namespace log4cplus
-{
-
-namespace internal
+namespace log4cplus::internal
 {
 
 log4cplus::tstring const empty_str;
-
-} // namespace internal
 
 } // namespace log4cplus
 
@@ -64,10 +59,7 @@ operator <<(log4cplus::tostream& stream, const char* str)
 #endif
 
 
-namespace log4cplus
-{
-
-namespace helpers
+namespace log4cplus::helpers
 {
 
 
@@ -522,7 +514,5 @@ CATCH_TEST_CASE( "Strings helpers", "[strings]" )
 #endif
 
 
-
-} // namespace helpers
 
 } // namespace log4cplus

--- a/src/syncprims.cxx
+++ b/src/syncprims.cxx
@@ -27,10 +27,7 @@
 #include <log4cplus/thread/syncprims-pub-impl.h>
 
 
-namespace log4cplus { namespace thread {
-
-
-namespace impl
+namespace log4cplus::thread::impl
 {
 
 
@@ -45,7 +42,4 @@ syncprims_throw_exception (char const * const msg, char const * const file,
 }
 
 
-}
-
-
-} } // namespace log4cplus { namespace thread namespace impl {
+} // namespace log4cplus::thread::impl

--- a/src/threads.cxx
+++ b/src/threads.cxx
@@ -68,7 +68,7 @@
 #endif // LOG4CPLUS_SINGLE_THREADED
 
 
-namespace log4cplus { namespace thread {
+namespace log4cplus::thread {
 
 LOG4CPLUS_EXPORT
 void
@@ -312,4 +312,4 @@ AbstractThread::~AbstractThread()
 #endif // LOG4CPLUS_SINGLE_THREADED
 
 
-} } // namespace log4cplus { namespace thread {
+} // namespace log4cplus::thread

--- a/src/timehelper.cxx
+++ b/src/timehelper.cxx
@@ -56,7 +56,7 @@
 #include <log4cplus/config/windowsh-inc.h>
 
 
-namespace log4cplus { namespace helpers {
+namespace log4cplus::helpers {
 
 const int ONE_SEC_IN_USEC = 1000000;
 
@@ -315,4 +315,4 @@ getFormattedTime(const log4cplus::tstring& fmt_orig,
 }
 
 
-} } // namespace log4cplus { namespace helpers {
+} // namespace log4cplus::helpers

--- a/src/tls.cxx
+++ b/src/tls.cxx
@@ -24,7 +24,7 @@
 #include <log4cplus/thread/impl/tls.h>
 
 
-namespace log4cplus { namespace thread { namespace impl {
+namespace log4cplus::thread::impl {
 
 
 #if defined (LOG4CPLUS_SINGLE_THREADED)
@@ -37,4 +37,4 @@ std::vector<tls_value_type> * tls_single_threaded_values;
 #endif
 
 
-} } } // namespace log4cplus { namespace thread { namespace impl {
+} // namespace log4cplus::thread::impl


### PR DESCRIPTION
See #441. Not all of the fixes have been integrated. In particular, these change sets have *not* been integrated: cbbc3ed2628ad2795a0b07b4bda48efaf7918e35, b2c9052d85d9b1b8dc63b6b7ddfa5d9407aa498c, e8da854f165627c33037586c52de0a3f93760353.