### PR TITLE
Fixes to the build issues on the modern iOS platform: architecture and compiler

### DIFF
--- a/iOS/iOS.cmake
+++ b/iOS/iOS.cmake
@@ -142,11 +142,10 @@ set (CMAKE_IOS_SDK_ROOT ${CMAKE_IOS_SDK_ROOT} CACHE PATH "Location of the select
 set (CMAKE_OSX_SYSROOT ${CMAKE_IOS_SDK_ROOT} CACHE PATH "Sysroot used for iOS support")
 
 # set the architecture for iOS 
-# NOTE: Currently both ARCHS_STANDARD_32_BIT and ARCHS_UNIVERSAL_IPHONE_OS set armv7 only, so set both manually
 if (${IOS_PLATFORM} STREQUAL "OS")
-	set (IOS_ARCH armv6 armv7)
+	set (IOS_ARCH arm64)
 else (${IOS_PLATFORM} STREQUAL "OS")
-	set (IOS_ARCH i386)
+	set (IOS_ARCH x86_64)
 endif (${IOS_PLATFORM} STREQUAL "OS")
 
 set (CMAKE_OSX_ARCHITECTURES ${IOS_ARCH} CACHE string  "Build architecture for iOS")

--- a/iOS/scripts/cmake_ios_armv7.sh
+++ b/iOS/scripts/cmake_ios_armv7.sh
@@ -13,7 +13,7 @@ cmake -G "Xcode" -DBUILD_SHARED_LIBS="FALSE" \
                  -DLOG4CPLUS_BUILD_LOGGINGSERVER="OFF" \
                  -DLOG4CPLUS_CONFIGURE_CHECKS_PATH=$scripts_dir/../ConfigureChecks.cmake \
                  -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=$scripts_dir/../build_armv7/Binaries \
-                 -DCMAKE_CXX_FLAGS="-std=c++11" \
+                 -DCMAKE_CXX_FLAGS="-std=c++17" \
                  $@ \
                  $scripts_dir/../..
 

--- a/iOS/scripts/cmake_ios_i386.sh
+++ b/iOS/scripts/cmake_ios_i386.sh
@@ -14,6 +14,7 @@ cmake -G "Xcode" -DBUILD_SHARED_LIBS="FALSE" \
                  -DLOG4CPLUS_BUILD_LOGGINGSERVER="OFF" \
                  -DLOG4CPLUS_CONFIGURE_CHECKS_PATH=$scripts_dir/../ConfigureChecks.cmake \
                  -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=$scripts_dir/../build_i386/Binaries \
+		 -DCMAKE_CXX_FLAGS="-std=c++17" \
                  $@ \
                  $scripts_dir/../..
 


### PR DESCRIPTION
Modern iOS targets require build for 64-bit architectures. So I changed that in the iOS.cmake file. 

I also changed the C++ standard to 17, so it even compiles - the code used declarations not available pre-17. 