### PR TITLE
configure.ac: check for libraries in C mode

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -412,6 +412,7 @@ LOG4CPLUS_DEFINE_MACRO_IF([LOG4CPLUS_HAVE_VAR_ATTRIBUTE_INIT_PRIORITY],
 
 dnl Checks for libraries.
 
+AC_LANG_PUSH([C])
 AC_SEARCH_LIBS([__atomic_fetch_and_4], [atomic])
 AC_SEARCH_LIBS([strerror], [cposix])
 dnl On some systems libcompat exists only as a static library which
@@ -422,6 +423,7 @@ AC_SEARCH_LIBS([setsockopt], [socket network net])
 AS_IF([test "x$with_iconv" = "xyes"],
   [AC_SEARCH_LIBS([iconv_open], [iconv], [],
      [AC_SEARCH_LIBS([libiconv_open], [iconv])])])
+AC_LANG_POP([C])
 
 dnl Windows/MinGW specific.
 
@@ -497,7 +499,9 @@ dnl Multi threaded library.
    AS_VAR_APPEND([LIBS], [" $PTHREAD_LIBS"])
 
    dnl required on HP-UX
+   AC_LANG_PUSH([C])
    AC_SEARCH_LIBS([sem_init], [rt])
+   AC_LANG_POP([C])
 
    AS_CASE([$ax_cv_cxx_compiler_vendor],
      [gnu|clang],


### PR DESCRIPTION
Fixes check for libraries failures, e.g. (from config.log):

```
  arc-buildroot-linux-uclibc-g++ -o conftest -Os -Wall -fdiagnostics-show-caret -ftrack-macro-expansion -fdiagnostics-color=auto -Wextra -pedantic -Wstrict-aliasing -Wstrict-overflow -Woverloaded-virtual -Wold-style-cast -Wc++14-compat -Wundef -Wshadow -Wformat -Wnoexcept -Wsuggest-attribute=format -Wsuggest-attribute=noreturn -Wno-variadic-macros -fvisibility=hidden conftest.cpp -latomic
  conftest.cpp:28:6: error: new declaration 'char __atomic_fetch_and_4()' ambiguates built-in declaration 'unsigned int __atomic_fetch_and_4(volatile void*, unsigned int, int)' [-fpermissive]
     28 | char __atomic_fetch_and_4 ();
        |      ^~~~~~~~~~~~~~~~~~~~
  conftest.cpp: In function 'int main()':
  conftest.cpp:32:30: error: too few arguments to function 'unsigned int __atomic_fetch_and_4(volatile void*, unsigned int, int)'
     32 | return __atomic_fetch_and_4 ();
        |                              ^
```

Resulting in:

	checking for library containing __atomic_fetch_and_4... no

instead (after the fix applied):

	checking for library containing __atomic_fetch_and_4... -latomic

Signed-off-by: Peter Seiderer <ps.report@gmx.net>