### PR TITLE
Simulate autotools behaviour in SO-NAME and symlink generation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,8 @@ include (Log4CPlusUtils.cmake)
 log4cplus_get_version ("${PROJECT_SOURCE_DIR}/include"
   log4cplus_version_major log4cplus_version_minor log4cplus_version_patch)
 message("-- Generating build for Log4cplus version ${log4cplus_version_major}.${log4cplus_version_minor}.${log4cplus_version_patch}")
-set (log4cplus_soversion 0)
+set (log4cplus_soversion 3)
+set (log4cplus_libtoolversion 0.0.0)
 set (log4cplus_postfix "")
 
 option(LOG4CPLUS_BUILD_TESTING "Build the test suite." ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -114,9 +114,20 @@ if (ANDROID)
   target_compile_definitions (${log4cplus} PRIVATE INSIDE_LOG4CPLUS)
 else ()
   set_target_properties (${log4cplus} PROPERTIES
-    VERSION "${log4cplus_version_major}.${log4cplus_version_minor}.${log4cplus_version_patch}"
-    SOVERSION "${log4cplus_soversion}")
+    VERSION "${log4cplus_libtoolversion}"
+    SOVERSION "${log4cplus_soversion}"
+    OUTPUT_NAME "${log4cplus}-${log4cplus_version_major}.${log4cplus_version_minor}")
   target_compile_definitions (${log4cplus} PRIVATE INSIDE_LOG4CPLUS)
+  get_target_property(libname ${log4cplus} OUTPUT_NAME)
+  get_target_property(libversion ${log4cplus} VERSION)
+  set(lib ${CMAKE_SHARED_LIBRARY_PREFIX})
+  set(so ${CMAKE_SHARED_LIBRARY_SUFFIX})
+  install(CODE "execute_process(
+    COMMAND bash -c \"set -e
+      cd $DESTDIR/${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}
+      echo -n -- Installing: `pwd`/
+      ln -sfv ${lib}${libname}${so}.${libversion} ${lib}${log4cplus}${so}
+      \")")
 endif ()
 
 if (MINGW AND LOG4CPLUS_MINGW_STATIC_RUNTIME)


### PR DESCRIPTION
This patch aligns cmake so that the SONAME and library name matches the output of autotools:

With autotools:  (build and then make install DESTDIR=sometmpdir)
```
tobi@isildor:~/workspace/deb/packages/log4cplus/upstream/log4cplus/build/tmp/usr/local/lib$ ls -la 
insgesamt 21448
drwxr-xr-x 3 tobi tobi     4096 28. Okt 18:08 .
drwxr-xr-x 4 tobi tobi     4096 28. Okt 18:08 ..
lrwxrwxrwx 1 tobi tobi       25 28. Okt 18:08 liblog4cplus-3.0.so.0 -> liblog4cplus-3.0.so.0.0.0
-rwxr-xr-x 1 tobi tobi 10671368 28. Okt 18:08 liblog4cplus-3.0.so.0.0.0
-rwxr-xr-x 1 tobi tobi      967 28. Okt 18:08 liblog4cplus.la
lrwxrwxrwx 1 tobi tobi       25 28. Okt 18:08 liblog4cplus.so -> liblog4cplus-3.0.so.0.0.0
drwxr-xr-x 2 tobi tobi     4096 28. Okt 18:08 pkgconfig
```
(the unicode flavour libs has been removed from above ls to illustrate the point better)

With CMake: (build and then make install DESTDIR=sometmpdir)
```
tobi@isildor:~/workspace/deb/packages/log4cplus/upstream/log4cplus/build_cmake/tmp/usr/local/lib$ ls -lah
insgesamt 6,4M
drwxr-xr-x 3 tobi tobi 4,0K 28. Okt 18:14 .
drwxr-xr-x 5 tobi tobi 4,0K 28. Okt 18:14 ..
drwxr-xr-x 3 tobi tobi 4,0K 28. Okt 18:14 cmake
lrwxrwxrwx 1 tobi tobi   21 28. Okt 18:14 liblog4cplus-3.0.so -> liblog4cplus-3.0.so.3
-rw-r--r-- 1 tobi tobi 6,4M 28. Okt 18:13 liblog4cplus-3.0.so.0.0.0
lrwxrwxrwx 1 tobi tobi   25 28. Okt 18:14 liblog4cplus-3.0.so.3 -> liblog4cplus-3.0.so.0.0.0
```

Please note that there is still one discrepancy: Autotools generates a SO-Version of zero (as configured in configure.ac) and CMake does a SO-Version of 3 (as you recently changed in https://github.com/wilx/log4cplus/commit/aa1a04c90c0590b44e3e3bb518c3eeaf41a7a8e1)  I left this to you to decide whether it sould be "zero" or "three", but it should be aligned.

Thanks!
