### PR TITLE
`filename` should not be empty for TimeBasedRollingFileAppender

### DIFF
--- a/src/fileappender.cxx
+++ b/src/fileappender.cxx
@@ -1356,7 +1356,10 @@ void
 TimeBasedRollingFileAppender::open(std::ios_base::openmode mode)
 {
     scheduledFilename = helpers::getFormattedTime(filenamePattern, helpers::now(), false);
-    tstring currentFilename = filename.empty() ? scheduledFilename : filename;
+    if (filename.empty())
+        filename = scheduledFilename;
+
+    tstring currentFilename = filename;
 
     if (createDirs)
         internal::make_dirs (currentFilename);
@@ -1401,7 +1404,7 @@ TimeBasedRollingFileAppender::rollover(bool alreadyLocked)
     // should remain unchanged on a close
     out.clear();
 
-    if (! filename.empty())
+    if (filename != scheduledFilename)
     {
         helpers::LogLog & loglog = helpers::getLogLog();
         long ret;


### PR DESCRIPTION
TimeBasedRollingFileAppender uses `filenamePattern` alone with current date time as opened filename and `filename` field is left empty almost all the time. This brings the problem when it calls `append()` method from the base class `FileAppenderBase`. The base class `FileAppenderBase` assumes that `filename` field is the path for opened file. Now this contract is broken.

Currently, this will cause log4cplus to print
```
"log4cplus:ERROR file is not open:"
```
when `out` stream is broken. It's confusing and misleading. Users may think that log4cplus tries to open a file with an empty name `""`.

This does not stop here, as long as it persists, more subtle bugs can be introduced.

This PR fixes this problem by setting `filename` to the name of the currently opened file in `TimeBasedRollingFileAppender::open()` making the contract valid again.
