### PR TITLE
Add LOG4CPLUS_NO_AUTO_DESTROY option.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,11 @@ if (LOG4CPLUS_REQUIRE_EXPLICIT_INITIALIZATION)
   add_compile_definitions (LOG4CPLUS_REQUIRE_EXPLICIT_INITIALIZATION=1)
 endif(LOG4CPLUS_REQUIRE_EXPLICIT_INITIALIZATION)
 
+option(LOG4CPLUS_NO_AUTO_DESTROY "Do not automatically destroy the default logging context")
+if (LOG4CPLUS_NO_AUTO_DESTROY)
+  add_compile_definitions (LOG4CPLUS_NO_AUTO_DESTROY=1)
+endif ()
+
 option(LOG4CPLUS_ENABLE_THREAD_POOL "Instantiate internal thread pool for when AsyncAppend=true" ON)
 if (LOG4CPLUS_ENABLE_THREAD_POOL)
 add_compile_definitions (LOG4CPLUS_ENABLE_THREAD_POOL=1)

--- a/src/global-init.cxx
+++ b/src/global-init.cxx
@@ -179,6 +179,7 @@ static DCState default_context_state = DC_UNINITIALIZED;
 static DefaultContext * default_context = nullptr;
 
 
+#if ! defined (LOG4CPLUS_NO_AUTO_DESTROY)
 struct destroy_default_context
 {
     ~destroy_default_context ()
@@ -189,6 +190,7 @@ struct destroy_default_context
     }
 } static destroy_default_context_
 LOG4CPLUS_INIT_PRIORITY (LOG4CPLUS_INIT_PRIORITY_BASE + 1);
+#endif
 
 
 static


### PR DESCRIPTION
We have experienced a problem that when log4cplus is used on Windows (with Visual Studio) as a DLL or statically linked into a DLL, that if the application is terminated by CTRL+C while log4cplus is initialized, the application hangs instead of exiting. Using the debugger revealed that it was hung in the destructor of `destroy_default_context` and further in the `ThreadPool` destructor, and that there was only a single thread at that time. Based on this observation, I think that Windows aborts all threads but still runs the static destructors. And of course the `ThreadPool` destructor hangs as it tries to synchronize with threads that no longer exist.

The only solution I could think of is to not destruct the default context from a static destructor. Therefore, this patch adds a new CMake option `LOG4CPLUS_NO_AUTO_DESTROY`, which if enabled, disables the `destroy_default_context` code. This completely solves the problem for us.