### PR TITLE
Coverity: replace while(0) with while(false)

### DIFF
--- a/include/log4cplus/loggingmacros.h
+++ b/include/log4cplus/loggingmacros.h
@@ -55,7 +55,7 @@
 
 #define LOG4CPLUS_DOWHILE_NOTHING()                 \
     LOG4CPLUS_SUPPRESS_DOWHILE_WARNING()            \
-    do { } while (0)                                \
+    do { } while (false)                            \
     LOG4CPLUS_RESTORE_DOWHILE_WARNING()
 
 #if defined(LOG4CPLUS_DISABLE_FATAL) && !defined(LOG4CPLUS_DISABLE_ERROR)
@@ -222,7 +222,7 @@ LOG4CPLUS_EXPORT void macro_forced_log (log4cplus::Logger const &,
                 LOG4CPLUS_MACRO_FILE (), __LINE__,                      \
                 LOG4CPLUS_MACRO_FUNCTION ());                           \
         }                                                               \
-    } while (0)                                                         \
+    } while (false)                                                     \
     LOG4CPLUS_RESTORE_DOWHILE_WARNING()
 
 
@@ -238,7 +238,7 @@ LOG4CPLUS_EXPORT void macro_forced_log (log4cplus::Logger const &,
                 LOG4CPLUS_MACRO_FILE (), __LINE__,                      \
                 LOG4CPLUS_MACRO_FUNCTION ());                           \
         }                                                               \
-    } while(0)                                                          \
+    } while (false)                                                     \
     LOG4CPLUS_RESTORE_DOWHILE_WARNING()
 
 #define LOG4CPLUS_MACRO_FMT_BODY(logger, logLevel, ...)                 \
@@ -256,7 +256,7 @@ LOG4CPLUS_EXPORT void macro_forced_log (log4cplus::Logger const &,
                 LOG4CPLUS_MACRO_FILE (), __LINE__,                      \
                 LOG4CPLUS_MACRO_FUNCTION ());                           \
         }                                                               \
-    } while(0)                                                          \
+    } while (false)                                                     \
     LOG4CPLUS_RESTORE_DOWHILE_WARNING()
 
 /**
@@ -398,7 +398,7 @@ LOG4CPLUS_EXPORT void macro_forced_log (log4cplus::Logger const &,
             LOG4CPLUS_FATAL_STR ((logger),                              \
                 LOG4CPLUS_TEXT ("failed condition: ")                   \
                 LOG4CPLUS_TEXT (LOG4CPLUS_ASSERT_STRINGIFY (condition))); \
-    } while (0)                                                         \
+    } while (false)                                                     \
     LOG4CPLUS_RESTORE_DOWHILE_WARNING()
 
 

--- a/include/log4cplus/thread/syncprims-pub-impl.h
+++ b/include/log4cplus/thread/syncprims-pub-impl.h
@@ -44,7 +44,7 @@
 
 #define LOG4CPLUS_THROW_RTE(msg) \
     do { log4cplus::thread::impl::syncprims_throw_exception (msg, __FILE__, \
-            __LINE__); } while (0)
+            __LINE__); } while (false)
 
 namespace log4cplus { namespace thread {
 

--- a/simpleserver/loggingserver.cxx
+++ b/simpleserver/loggingserver.cxx
@@ -190,7 +190,7 @@ loggingserver::ClientThread::run()
 {
     try
     {
-        while (1)
+        while (true)
         {
             if (!clientsock.isOpen())
                 break;


### PR DESCRIPTION
fix some coverity warnings by using while(false) instead of while(0).

The program was tested solely for our own use cases, which might differ from yours.

Changes to include/log4cplus/thread/syncprims-pub-impl.h are licensed under Two clause BSD license.
Changes to include/log4cplus/loggingmacros.h and simpleserver/loggingserver.cxx are
licensed under Apache License, Version 2.0.

<sup>Ahmet Findikci <ahmet.findikci@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH, [imprint](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)</sup> 