### PR TITLE
Allow non-FQDN hostname in syslog messages.

### DIFF
--- a/include/log4cplus/helpers/socket.h
+++ b/include/log4cplus/helpers/socket.h
@@ -31,6 +31,7 @@
 #endif
 
 #include <array>
+#include <optional>
 
 #include <log4cplus/tstring.h>
 #include <log4cplus/helpers/socketbuffer.h>
@@ -154,7 +155,7 @@ namespace log4cplus {
         LOG4CPLUS_EXPORT long write(SOCKET_TYPE sock,
             const std::string & buffer);
 
-        LOG4CPLUS_EXPORT tstring getHostname (bool fqdn);
+        LOG4CPLUS_EXPORT std::optional<tstring> getHostname (bool fqdn);
         LOG4CPLUS_EXPORT int setTCPNoDelay (SOCKET_TYPE, bool);
 
     } // end namespace helpers

--- a/include/log4cplus/syslogappender.h
+++ b/include/log4cplus/syslogappender.h
@@ -71,6 +71,10 @@ namespace log4cplus
      * <dd>Boolean value specifying whether to use IPv6 (true) or IPv4
      * (false). Default value is false.</dd>
      *
+     * <dt><tt>fqdn</tt></dt>
+     * <dd>Boolean value specifying whether to use FQDN for hostname field.
+     * Default value is true.</dd>
+     *
      * </dl>
      *
      * \note Messages sent to remote syslog using UDP are conforming
@@ -97,7 +101,7 @@ namespace log4cplus
 #endif
         SysLogAppender(const tstring& ident, const tstring & host,
             int port = 514, const tstring & facility = tstring (),
-            RemoteSyslogType remoteSyslogType = RSTUdp, bool ipv6 = false);
+            RemoteSyslogType remoteSyslogType = RSTUdp, bool ipv6 = false, bool fqdn = true);
         SysLogAppender(const log4cplus::helpers::Properties & properties);
 
       // Dtor

--- a/src/patternlayout.cxx
+++ b/src/patternlayout.cxx
@@ -610,7 +610,7 @@ RelativeTimestampConverter::convert (tstring & result,
 HostnamePatternConverter::HostnamePatternConverter (
     const FormattingInfo& info, bool fqdn)
     : PatternConverter(info)
-    , hostname_ (helpers::getHostname (fqdn))
+    , hostname_ (helpers::getHostname (fqdn).value_or ("-"))
 { }
 
 

--- a/src/patternlayout.cxx
+++ b/src/patternlayout.cxx
@@ -610,7 +610,7 @@ RelativeTimestampConverter::convert (tstring & result,
 HostnamePatternConverter::HostnamePatternConverter (
     const FormattingInfo& info, bool fqdn)
     : PatternConverter(info)
-    , hostname_ (helpers::getHostname (fqdn).value_or ("-"))
+    , hostname_ (helpers::getHostname (fqdn).value_or (LOG4CPLUS_C_STR_TO_TSTRING ("-")))
 { }
 
 

--- a/src/socket-unix.cxx
+++ b/src/socket-unix.cxx
@@ -457,11 +457,17 @@ getHostname (bool fqdn)
             hostname = &hn[0];
             break;
         }
+        else if (false
 #if defined (LOG4CPLUS_HAVE_ENAMETOOLONG)
-        else if (errno == ENAMETOOLONG)
+                 || errno == ENAMETOOLONG
+#endif
+#if defined (__GLIBC__) || defined (__GNU_LIBRARY__)
+                 // Before version 2.1, glibc uses EINVAL for this case.
+                 || errno == EINVAL
+#endif
+        )
             // Out buffer was too short. Retry with buffer twice the size.
             hn.resize (hn.size () * 2, 0);
-#endif
         else
             break;
     }

--- a/src/socket-unix.cxx
+++ b/src/socket-unix.cxx
@@ -442,10 +442,10 @@ write(SOCKET_TYPE sock, const std::string & buffer)
 }
 
 
-tstring
+std::optional<tstring>
 getHostname (bool fqdn)
 {
-    char const * hostname = "unknown";
+    char const * hostname = nullptr;
     int ret;
     std::vector<char> hn (1024, 0);
 
@@ -469,18 +469,18 @@ getHostname (bool fqdn)
             // Out buffer was too short. Retry with buffer twice the size.
             hn.resize (hn.size () * 2, 0);
         else
-            break;
+            return { };
     }
 
-    if (ret != 0 || (ret == 0 && ! fqdn))
-        return LOG4CPLUS_STRING_TO_TSTRING (hostname);
+    if (! fqdn)
+        return { LOG4CPLUS_C_STR_TO_TSTRING (hostname) };
 
     std::string full_hostname;
     ret = get_host_by_name (hostname, &full_hostname, nullptr);
     if (ret == 0)
-        hostname = full_hostname.c_str ();
+        return { LOG4CPLUS_STRING_TO_TSTRING (full_hostname) };
 
-    return LOG4CPLUS_STRING_TO_TSTRING (hostname);
+    return { LOG4CPLUS_C_STR_TO_TSTRING (hostname) };
 }
 
 

--- a/src/socket-win32.cxx
+++ b/src/socket-win32.cxx
@@ -419,12 +419,12 @@ verifyWindowsVersionAtLeast (DWORD major, DWORD minor)
 }
 
 
-tstring
+std::optional<tstring>
 getHostname (bool fqdn)
 {
     init_winsock ();
 
-    char const * hostname = "unknown";
+    char const * hostname = nullptr;
     int ret;
     // The initial size is based on information in the Microsoft article
     // <https://msdn.microsoft.com/en-us/library/ms738527(v=vs.85).aspx>
@@ -449,13 +449,13 @@ getHostname (bool fqdn)
                 helpers::getLogLog().error(
                     LOG4CPLUS_TEXT("Failed to get own hostname. Error: ")
                     + convertIntegerToString (wsaeno));
-                return LOG4CPLUS_STRING_TO_TSTRING (hostname);
+                return { };
             }
         }
     }
 
-    if (ret != 0 || (ret == 0 && ! fqdn))
-        return LOG4CPLUS_STRING_TO_TSTRING (hostname);
+    if (! fqdn)
+        return { LOG4CPLUS_C_STR_TO_TSTRING (hostname) };
 
     ADDRINFOT addr_info_hints{ };
     addr_info_hints.ai_family = AF_INET;
@@ -477,11 +477,11 @@ getHostname (bool fqdn)
         helpers::getLogLog ().error (
             LOG4CPLUS_TEXT ("Failed to resolve own hostname. Error: ")
             + convertIntegerToString (ret));
-        return LOG4CPLUS_STRING_TO_TSTRING (hostname);
+        return { LOG4CPLUS_C_STR_TO_TSTRING (hostname) };
     }
 
     addr_info.reset (ai);
-    return addr_info->ai_canonname;
+    return { addr_info->ai_canonname };
 }
 
 

--- a/src/socket.cxx
+++ b/src/socket.cxx
@@ -22,6 +22,9 @@
 #include <log4cplus/internal/socket.h>
 #include <log4cplus/internal/internal.h>
 
+#if defined (LOG4CPLUS_WITH_UNIT_TESTS)
+#include <catch.hpp>
+#endif
 
 namespace log4cplus::helpers {
 
@@ -260,6 +263,28 @@ openSocket(unsigned short port, bool udp, bool ipv6, SocketState& state)
 {
     return openSocket(log4cplus::internal::empty_str, port, udp, ipv6, state);
 }
+
+
+#if defined (LOG4CPLUS_WITH_UNIT_TESTS)
+CATCH_TEST_CASE ("Socket", "[sockets]")
+{
+    CATCH_SECTION ("hostname resolution")
+    {
+        CATCH_SECTION ("FQDN")
+        {
+            auto result = getHostname(true);
+            CATCH_REQUIRE (result.has_value ());
+
+        }
+
+        CATCH_SECTION ("non-FQDN")
+        {
+            auto result = getHostname(false);
+            CATCH_REQUIRE (result.has_value ());
+        }
+    }
+}
+#endif // LOG4CPLUS_WITH_UNIT_TESTS
 
 
 } // namespace log4cplus::helpers

--- a/src/syslogappender.cxx
+++ b/src/syslogappender.cxx
@@ -230,7 +230,7 @@ SysLogAppender::SysLogAppender(const tstring& id)
     // the address of the c_str() result remains stable for openlog &
     // co to use even if we use wstrings.
     , identStr(LOG4CPLUS_TSTRING_TO_STRING (id) )
-    , hostname (helpers::getHostname (true))
+    , hostname (helpers::getHostname (true).value_or ("-"))
 {
     ::openlog(useIdent(identStr), 0, 0);
 }
@@ -259,7 +259,7 @@ SysLogAppender::SysLogAppender(const helpers::Properties & properties)
 
     bool fqdn = true;
     properties.getBool (fqdn, LOG4CPLUS_TEXT ("fqdn"));
-    hostname = std::move(helpers::getHostname (fqdn));
+    hostname = std::move(helpers::getHostname (fqdn).value_or ("-"));
 
     properties.getString (host, LOG4CPLUS_TEXT ("host"))
       || properties.getString (host, LOG4CPLUS_TEXT ("SyslogHost"));
@@ -303,7 +303,7 @@ SysLogAppender::SysLogAppender(const tstring& id, const tstring & h,
     // the address of the c_str() result remains stable for openlog &
     // co to use even if we use wstrings.
     , identStr(LOG4CPLUS_TSTRING_TO_STRING (id) )
-    , hostname (helpers::getHostname (fqdn))
+    , hostname (helpers::getHostname (fqdn).value_or ("-"))
 {
     openSocket ();
     initConnector ();

--- a/src/syslogappender.cxx
+++ b/src/syslogappender.cxx
@@ -230,7 +230,7 @@ SysLogAppender::SysLogAppender(const tstring& id)
     // the address of the c_str() result remains stable for openlog &
     // co to use even if we use wstrings.
     , identStr(LOG4CPLUS_TSTRING_TO_STRING (id) )
-    , hostname (helpers::getHostname (true).value_or ("-"))
+    , hostname (helpers::getHostname (true).value_or (LOG4CPLUS_C_STR_TO_TSTRING ("-")))
 {
     ::openlog(useIdent(identStr), 0, 0);
 }
@@ -259,7 +259,7 @@ SysLogAppender::SysLogAppender(const helpers::Properties & properties)
 
     bool fqdn = true;
     properties.getBool (fqdn, LOG4CPLUS_TEXT ("fqdn"));
-    hostname = std::move(helpers::getHostname (fqdn).value_or ("-"));
+    hostname = std::move(helpers::getHostname (fqdn).value_or (LOG4CPLUS_C_STR_TO_TSTRING ("-")));
 
     properties.getString (host, LOG4CPLUS_TEXT ("host"))
       || properties.getString (host, LOG4CPLUS_TEXT ("SyslogHost"));
@@ -303,7 +303,7 @@ SysLogAppender::SysLogAppender(const tstring& id, const tstring & h,
     // the address of the c_str() result remains stable for openlog &
     // co to use even if we use wstrings.
     , identStr(LOG4CPLUS_TSTRING_TO_STRING (id) )
-    , hostname (helpers::getHostname (fqdn).value_or ("-"))
+    , hostname (helpers::getHostname (fqdn).value_or (LOG4CPLUS_C_STR_TO_TSTRING ("-")))
 {
     openSocket ();
     initConnector ();

--- a/src/syslogappender.cxx
+++ b/src/syslogappender.cxx
@@ -244,7 +244,6 @@ SysLogAppender::SysLogAppender(const helpers::Properties & properties)
     , appendFunc (nullptr)
     , port (0)
     , connected (false)
-    , hostname (helpers::getHostname (true))
 {
     ident = properties.getProperty( LOG4CPLUS_TEXT("ident") );
     facility = parseFacility (
@@ -257,6 +256,10 @@ SysLogAppender::SysLogAppender(const helpers::Properties & properties)
     remoteSyslogType = udp ? RSTUdp : RSTTcp;
 
     properties.getBool (ipv6, LOG4CPLUS_TEXT ("IPv6"));
+
+    bool fqdn = true;
+    properties.getBool (fqdn, LOG4CPLUS_TEXT ("fqdn"));
+    hostname = std::move(helpers::getHostname (fqdn));
 
     properties.getString (host, LOG4CPLUS_TEXT ("host"))
       || properties.getString (host, LOG4CPLUS_TEXT ("SyslogHost"));
@@ -287,7 +290,7 @@ SysLogAppender::SysLogAppender(const helpers::Properties & properties)
 
 SysLogAppender::SysLogAppender(const tstring& id, const tstring & h,
     int p, const tstring & f, SysLogAppender::RemoteSyslogType rst,
-    bool ipv6_ /*= false*/)
+    bool ipv6_ /*= false*/, bool fqdn /*= true*/)
     : ident (id)
     , facility (parseFacility (helpers::toLower (f)))
     , appendFunc (&SysLogAppender::appendRemote)
@@ -300,7 +303,7 @@ SysLogAppender::SysLogAppender(const tstring& id, const tstring & h,
     // the address of the c_str() result remains stable for openlog &
     // co to use even if we use wstrings.
     , identStr(LOG4CPLUS_TSTRING_TO_STRING (id) )
-    , hostname (helpers::getHostname (true))
+    , hostname (helpers::getHostname (fqdn))
 {
     openSocket ();
     initConnector ();


### PR DESCRIPTION
Implements #570.