### PR TITLE
config: resolve environment variables in include

### DIFF
--- a/include/log4cplus/helpers/property.h
+++ b/include/log4cplus/helpers/property.h
@@ -155,6 +155,15 @@ namespace log4cplus {
             bool get_type_val_worker (ValType & val,
                 log4cplus::tstring const & key) const;
         };
+
+
+        class LogLog;
+
+
+        bool
+        substVars (tstring & dest, const tstring & val,
+            Properties const & props, LogLog& loglog,
+            unsigned flags);
     } // end namespace helpers
 
 }


### PR DESCRIPTION
Enable resolving environment variables in the include statement of configuration files. The path of the included file may contain environment variables.