### PR TITLE
Fix UNICODE comment typo

### DIFF
--- a/include/log4cplus/clogger.h
+++ b/include/log4cplus/clogger.h
@@ -39,7 +39,7 @@ extern "C"
 {
 #endif
 
-// TODO UNICDE capable
+// TODO UNICODE capable
 
 typedef void * log4cplus_logger_t;
 typedef log4cplus_logger_t logger_t;


### PR DESCRIPTION
## Summary
- correct typo in C API TODO comment

## Testing
- `doxygen docs/doxygen.config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ffd16fda483208fd689c18a070cd5