### PR TITLE
Fix grammar in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,9 @@ configuration.  It is modeled after the Java log4j API.
 Latest Project Information
 ==========================
 
-The latest up-to-date information for this project can be found
-on [GitHub][13] project page or [log4cplus wiki][4] there.
-Please submit bugs, patches, feature requests, etc.,
-on [GitHub][13].
+The latest up-to-date information for this project can be found on the
+[GitHub][13] project page or the [log4cplus wiki][4]. Please submit bugs,
+patches, feature requests, and so on on [GitHub][13].
 
 [4]: https://github.com/log4cplus/log4cplus/wiki
 [13]: https://github.com/log4cplus/log4cplus
@@ -25,11 +24,11 @@ on [GitHub][13].
 Mission statement
 =================
 
-The aim of this project is to develop log4j--like logging framework
-for use in (primarily) C++. One of the major design goals is to avoid
+The aim of this project is to develop a log4j-like logging framework for
+use primarily in C++. One of the major design goals is to avoid
 huge dependencies (like Boost) in the core functionality and to use
 standard C++ facilities instead. Where possible, the project takes
-inspiration from other logging libraries, beside from log4j (e.g.,
+inspiration from other logging libraries, besides log4j (e.g.,
 from log4net, log4cxx, log4cpp).
 
 
@@ -52,15 +51,15 @@ ported to and tested on the following platforms:
     (FreeBSD Ports Collection)
   - OpenIndiana Hipster 2016.10 with GCC version 4.9.4
 
-The testing on the above listed platforms has been done at some point
-in time with some version of source. Continuous testing is done only
-on Linux platform offered by [Travis CI][11] service.
+Testing on the above-listed platforms was done at some point in time
+with some version of the source. Continuous testing is performed only
+on the Linux platform offered by the [Travis CI][11] service.
 
 The oldest Windows version that is supported by 2.x releases is Windows Vista.
 
 The following platforms were supported by the 1.x series of [log4cplus]. They
-either do not have a reasonable C++23 capable compiler or have not been checked
-with [log4cplus] 3.x, yet:
+either do not have a reasonably C++23-capable compiler or have not yet been
+checked with [log4cplus] 3.x:
 
   - Minix 3.3.0/i386 with Clang version 3.4 (branches/release_34) with
     `--disable-threads`
@@ -75,11 +74,11 @@ with [log4cplus] 3.x, yet:
   - AIX 5.3 with IBM XL C/C++ for AIX
 
 
-Installation instruction
-========================
+Installation instructions
+=========================
 
-Generic Autotools installation instructions are in `INSTALL` file.  The
-following are [log4cplus] specific instructions.
+Generic Autotools installation instructions are in the `INSTALL` file. The
+following are [log4cplus]-specific instructions.
 
 [log4cplus] uses Git sub-modules. Always use `--recurse-submodules` option when
 doing `git clone`.
@@ -146,8 +145,8 @@ compiler and linker flags that enable POSIX threading support.
 
 While this detection usually works well, some platforms still need
 help with configuration by supplying additional flags to the
-`configure` script.  One of the know deficiencies is Solaris Studio on
-Linux.  See one of the later note for details.
+`configure` script. One of the known deficiencies is Solaris Studio on
+Linux. See one of the later notes for details.
 
 
 `--enable-tests`
@@ -159,9 +158,9 @@ This option is enabled by default.  It enables compilation of test executables.
 `--enable-unit-tests`
 ---------------------
 
-This option is disabled by default.  It enables compilation of unit tests along
-their units.  These unit tests then can be executed through `unit_tests` test
-executable that is built during compilation.
+This option is disabled by default. It enables compilation of unit tests along
+with their units. These unit tests can then be executed through the
+`unit_tests` test executable that is built during compilation.
 
 
 `--enable-implicit-initialization`
@@ -194,7 +193,7 @@ flag. In effect, these binaries assume that `log4cplus::tchar` is `wchar_t`.
 This is one of three locale and `wchar_t`↔`char` conversion related
 options.  It is disabled by default.
 
-It is know to work well with GCC on Linux.  Other platforms generally
+It is known to work well with GCC on Linux. Other platforms generally
 have lesser locale support in their implementations of the C++
 standard library.  It is known not to work well on any BSDs.
 
@@ -204,7 +203,7 @@ See also docs/unicode.txt.
 `--with-working-c-locale`
 -------------------------
 
-This is second of `wchar_t`↔`char` conversion related options.  It is
+This is the second of the `wchar_t`↔`char` conversion-related options. It is
 disabled by default.
 
 It is known to work well on most Unix--like platforms, including
@@ -214,7 +213,7 @@ recent Cygwin.
 `--with-iconv`
 --------------
 
-This is third of `wchar_t`↔`char` conversion related options.  It is
+This is the third of the `wchar_t`↔`char` conversion-related options. It is
 disabled by default.
 
 The conversion using iconv() function always uses `"UTF-8"` and
@@ -222,8 +221,8 @@ The conversion using iconv() function always uses `"UTF-8"` and
 platforms with GNU iconv.  Different implementations of `iconv()`
 might not support `"WCHAR_T"` encoding selector.
 
-Either system provided `iconv()` or library provided `libiconv()` are
-detected and accepted.  Also both SUSv3 and GNU `iconv()` function
+Either the system-provided `iconv()` or the library-provided `libiconv()` is
+detected and accepted. Both SUSv3 and GNU `iconv()` function
 signatures are accepted.
 
 
@@ -249,16 +248,16 @@ Notes
 Compilation
 -----------
 
-On Unix--like platforms, [log4cplus] can be compiled using either
-autotools based build system or using CMake build system. The
-autotools based build system is considered to be primary for
+On Unix--like platforms, [log4cplus] can be compiled using either the
+Autotools-based build system or the CMake build system. The
+Autotools-based build system is considered to be primary for
 Unix--like platforms.
 
 On Windows, the primary build system is Visual Studio 2015 solution
 and projects (`msvc14/log4cplus.sln`).
 
-MinGW is supported by autotools based build system. CMake build system
-is supported as well and it should be used to compile [log4cplus] with
+MinGW is supported by the Autotools-based build system. The CMake build system
+is supported as well, and it should be used to compile [log4cplus] with
 older versions of Visual Studio or with less common compiler suites
 (e.g., Embarcadero, Code::Blocks, etc.).
 
@@ -266,9 +265,9 @@ older versions of Visual Studio or with less common compiler suites
 Cygwin
 ------
 
-Cygwin 2.5.x has a problem[^pr64697] linking binaries that use language level
+Cygwin 2.5.x has a problem[^pr64697] linking binaries that use language-level
 thread-local storage and share thread-local variables across translation
-units. To avoid the issue language level thread-local storage is not used on
+units. To avoid the issue, language-level thread-local storage is not used on
 Cygwin and traditional POSIX thread-local storage is used instead.
 
 [^pr64697]: <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64697>
@@ -278,11 +277,11 @@ MinGW and MSVCRT version
 ------------------------
 
 [log4cplus] can use functions like `_vsnprintf_s()` (Microsoft's
-secure version of `vsnprintf()`). MinGW tool--chains (by default) link
+secure version of `vsnprintf()`). MinGW toolchains (by default) link
 to the system `MSVCRT.DLL`. Unfortunately, older systems, like Windows
 XP, ship with `MSVCRT.DLL` that lacks these functions. It is possible
-to compile [log4cplus] with MinGW tool--chains but _without_ using
-Microsoft's secure functions by defining `__MSVCRT_VERSION__` to value
+to compile [log4cplus] with MinGW toolchains but _without_ using
+Microsoft's secure functions by defining `__MSVCRT_VERSION__` to a value
 less than `0x900` and vice versa.
 
     $ ../configure CPPFLAGS="-D__MSVCRT_VERSION__=0x700"
@@ -318,11 +317,11 @@ instances are destroyed.
 Windows and rolling file Appenders
 ----------------------------------
 
-On Windows, the standard C++ file streams open files in way that underlying
-Win32 file `HANDLE` is not open with `FILE_SHARE_DELETE` flag. This flag,
-beside shared delete, allows renaming files that have handles open to
-them. This issue manifests as error code 13 when the file needs to be rolled
-over and it is still open by another process.
+On Windows, the standard C++ file streams open files in a way that the
+underlying Win32 file `HANDLE` is not opened with the `FILE_SHARE_DELETE`
+flag. This flag, besides shared delete, allows renaming files that have
+handles open to them. This issue manifests as error code 13 when the file
+needs to be rolled over while it is still open by another process.
 
 This is also [bug #167](https://sourceforge.net/p/log4cplus/bugs/167/) on
 SourceForge.
@@ -355,7 +354,7 @@ compiling [log4cplus] targeted to Windows Vista or later.
 Linking on Windows
 ------------------
 
-If you are linking your application with DLL variant of [log4cplus], define
+If you are linking your application with the DLL variant of [log4cplus], define
 `LOG4CPLUS_BUILD_DLL` preprocessor symbol. This changes definition of
 `LOG4CPLUS_EXPORT` symbol to `__declspec(dllimport)`.
 
@@ -404,7 +403,7 @@ variants that support threading using the `CXX` variable on
 AIX reentrancy problem
 ----------------------
 
-There appears to be a reentracy problem with AIX 5.3 and xlC 8 which
+There appears to be a reentrancy problem with AIX 5.3 and xlC 8 which
 can result into a deadlock condition in some circumstances.  It is
 unknown whether the problem manifests with other versions of either
 the OS or the compiler, too.  The problem was initially reported in a
@@ -454,8 +453,8 @@ your application's build flags as well.
 Solaris Studio on GNU/Linux
 ---------------------------
 
-The autotools and our `configure.ac` combo does not handle Solaris
-Studio compiler on Linux well enough and needs a little help with
+The Autotools and our `configure.ac` combination do not handle the Solaris
+Studio compiler on Linux well enough and need a little help with the
 configuration of POSIX threads:
 
 ```sh
@@ -505,33 +504,33 @@ Haiku
 
 Haiku is supported with GCC 4+. The default GCC version in Haiku is
 set to version 2 (based on GCC 2.95.x). To change the default GCC
-version to version 4, please run `setgcc gcc4` command. This is to
+version to 4, please run the `setgcc gcc4` command. This is to
 avoid linking errors like this:
 
     main.cpp:(.text.startup+0x54a): undefined reference to `_Unwind_Resume'
 
 Running the command switches the _current_ GCC version to version 4.
-This change is permanent and global. See also Haiku ticket
+This change is permanent and global. See also the Haiku ticket
 [#8368](https://dev.haiku-os.org/ticket/8368).
 
 
 Qt4 / Win32 / MSVC
 ------------------
 
-In order to use [log4cplus] in Qt4 programs it is necessary to set
-following option: `Treat WChar_t As Built in Type: No (/Zc:wchar_t-)`
+In order to use [log4cplus] in Qt4 programs it is necessary to set the
+following option: `Treat WChar_t As Built-in Type: No (/Zc:wchar_t-)`
 
-Set this option for [log4cplus] project and `Qt4DebugAppender` project
-in MS Visual Studio.  Remember to use Unicode versions of [log4cplus]
-libraries with Qt.  It is also necessary to make clear distinction
-between debug and release builds of Qt project and [log4cplus].  Do
-not use [log4cplus] release library with debug version of Qt program
-and vice versa.
+Set this option for the [log4cplus] project and the `Qt4DebugAppender`
+project in MS Visual Studio. Remember to use the Unicode versions of
+[log4cplus] libraries with Qt. It is also necessary to make a clear
+distinction between debug and release builds of the Qt project and
+[log4cplus]. Do not use the [log4cplus] release library with the debug
+version of a Qt program and vice versa.
 
-For registering Qt4DebugAppender library at runtime, call this
+To register the Qt4DebugAppender library at runtime, call this
 function: `log4cplus::Qt4DebugAppender::registerAppender()`
 
-Add these lines to qmake project file for using [log4cplus] and
+Add these lines to the qmake project file to use [log4cplus] and
 `Qt4DebugAppender`:
 
     INCLUDEPATH += C:\log4cplus\include
@@ -597,7 +596,7 @@ Edit the `iOS.cmake` file and add these two lines.
     set (CMAKE_CXX_COMPILER_WORKS TRUE)
     set (CMAKE_C_COMPILER_WORKS TRUE)
 
-Add these lines. Customize them accordingly:
+Add these lines, customizing them accordingly:
 
     set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
     set(CMAKE_MACOSX_BUNDLE YES)
@@ -617,17 +616,17 @@ If you have issues with TLS, also comment out these lines:
 
 Beware, the `%s` specifier does not work the same way on Unix--like
 platforms as it does on Windows with Visual Studio. With Visual Studio
-the `%s` specifier changes its meaning conveniently by printing
-`wchar_t` string when used with `wprintf()` and `char` strings when
-used with `printf()`.  On the other hand, Unix--like platforms keeps
-the meaning of printing `char` strings when used with both `wprintf()`
-and `printf()`.  It is necessary to use `%ls` (C99) specifier or `%S`
-(SUSv2) specifier to print `wchar_t` strings on Unix--like platforms.
+the `%s` specifier changes its meaning by printing a `wchar_t` string
+when used with `wprintf()` and a `char` string when used with
+`printf()`. On the other hand, Unix-like platforms keep the meaning of
+printing `char` strings when used with both `wprintf()` and
+`printf()`. It is necessary to use the `%ls` (C99) specifier or the `%S`
+(SUSv2) specifier to print `wchar_t` strings on Unix-like platforms.
 
-The common ground for both platforms appears to be use of `%ls` and
-`wchar_t` string to print strings with unmodified formatting string
-argument on both Unix--like platforms and Windows. The conversion of
-`wchar_t` back to `char` then depends on C locale.
+The common ground for both platforms appears to be using `%ls` and a
+`wchar_t` string to print strings with an unmodified format string on
+both Unix-like platforms and Windows. The conversion of `wchar_t` back
+to `char` then depends on the C locale.
 
 
 Unsupported compilers and platforms
@@ -678,17 +677,17 @@ For successful resolution of reported bugs, it is necessary to provide enough in
 License
 =======
 
-This library is licensed under the Apache Public License 2.0 and two
-clause BSD license.  Please read the included [LICENSE](./LICENSE) file for
+This library is licensed under the Apache Public License 2.0 and the
+two-clause BSD license. Please read the included [LICENSE](./LICENSE) file for
 details.
 
 
 Contributions
 =============
 
-[log4cplus] (bug tracker, files, wiki) is hosted on GitHub.
-See also [Contributions](https://github.com/log4cplus/log4cplus/wiki/Development#contributions)
-topic on wiki.
+[log4cplus] (bug tracker, files, wiki) is hosted on GitHub. See also the
+[Contributions](https://github.com/log4cplus/log4cplus/wiki/Development#contributions)
+topic on the wiki.
 
 
 Patches
@@ -702,9 +701,9 @@ form: a merge request of a Git branch.
 Formatting
 ----------
 
-Please use common sense. Follow the style of surrounding code. You can
-use the following Emacs style that is based on Microsoft's style as a
-guide line:
+Please use common sense. Follow the style of the surrounding code. You can
+use the following Emacs style, which is based on Microsoft's style, as a
+guideline:
 
 ```lisp
 ;; Custom MS like indentation style.
@@ -731,23 +730,23 @@ Autotools is considered the primary build system on Unix--like
 platforms. However, CMake should still be usable on Unix--like platforms as
 well.
 
-On Windows, it depends on compiler and tool-chain that you want to use. When
+On Windows, it depends on the compiler and toolchain that you want to use. When
 using Visual Studio, use Visual Studio solution and project files. However,
-CMake build system should still work and produce useful results. When using
-some form of MinGW64 tool-chain, the CMake build system is considered primary
-and the Autotools based build system is unsupported. Use the `MinGW Makefiles`
+the CMake build system should still work and produce useful results. When using
+some form of MinGW64 toolchain, the CMake build system is considered primary
+and the Autotools-based build system is unsupported. Use the `MinGW Makefiles`
 option and build with `mingw-make` (or similar). The `MSYS Makefiles` option is
 untested and unsupported.
 
 #### Autotools
 
-The `Makefile.am` files for this build systems are hand written. Some of them,
+The `Makefile.am` files for this build system are hand-written. Some of them,
 however, are generated from `Makefile.am.tpl` and `Makefile.am.def` by
 [GNU Autogen][12]. This is to make adding new files to the source easier.
 
 To regenerate `Makefile.am` files, `configure` script, `testsuite` script or
 any other part of the Autotools build system, use the `scripts/doautoreconf.sh`
-script from source root directory. It will invoke all the necessary tools in
+script from the source root directory. It will invoke all the necessary tools in
 the correct order.
 
 [log4cplus] closely follows Autoconf's, Automake's and Libtool's development


### PR DESCRIPTION
## Summary
- clean up README grammar and punctuation
- no code changes

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON`
- `cmake --build build -- -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_684000f39bb88320a4d4ec71ea4f19d3