### PR TITLE
Fix grammar in comments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,7 @@ if (WITH_UNIT_TESTS)
     add_compile_definitions (LOG4CPLUS_WITH_UNIT_TESTS=1
       NOMINMAX=1)
     if (MSVC AND MSVC_TOOLSET_VERSION VERSION_LESS "143")
-      message (WARNING "Adding /Zc:hiddenFriend- compiler flag to workaround Catch2 complation issue with Visual Studio 2019")
+      message (WARNING "Adding /Zc:hiddenFriend- compiler flag to work around Catch2 compilation issue with Visual Studio 2019")
       add_compile_options (/Zc:hiddenFriend-)
     endif ()
   endif (WIN32)

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 dnl Process this file with autoconf to produce a configure script.
-dnl This version of log4cplus requires the follwing autotools versions:
+dnl This version of log4cplus requires the following autotools versions:
 dnl autoconf-2.69
 dnl automake-1.16.1
 dnl libtool-2.4.6
@@ -487,7 +487,7 @@ LOG4CPLUS_CHECK_HEADER([poll.h], [LOG4CPLUS_HAVE_POLL_H])
 AS_IF([test "x$with_iconv" = "xyes"],
   [LOG4CPLUS_CHECK_HEADER([iconv.h], [LOG4CPLUS_HAVE_ICONV_H])])
 
-dnl Check for the existance of type socklen_t.
+dnl Check for the existence of type socklen_t.
 
 AX_TYPE_SOCKLEN_T
 

--- a/docs/webpage_doxygen.config
+++ b/docs/webpage_doxygen.config
@@ -1092,7 +1092,7 @@ HTML_STYLESHEET        = doxygen.css
 # cascading style sheets that are included after the standard style sheets
 # created by doxygen. Using this option one can overrule certain style aspects.
 # This is preferred over using HTML_STYLESHEET since it does not replace the
-# standard style sheet and is therefor more robust against future updates.
+# standard style sheet and is therefore more robust against future updates.
 # Doxygen will copy the style sheet files to the output directory.
 # Note: The order of the extra stylesheet files is of importance (e.g. the last
 # stylesheet in the list overrules the setting of the previous ones in the
@@ -1635,8 +1635,8 @@ EXTRA_PACKAGES         =
 # Note: Only use a user-defined header if you know what you are doing! The
 # following commands have a special meaning inside the header: $title,
 # $datetime, $date, $doxygenversion, $projectname, $projectnumber,
-# $projectbrief, $projectlogo. Doxygen will replace $title with the empy string,
-# for the replacement values of the other commands the user is refered to
+# $projectbrief, $projectlogo. Doxygen will replace $title with the empty string,
+# for the replacement values of the other commands the user is referred to
 # HTML_HEADER.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 

--- a/include/log4cplus/appender.h
+++ b/include/log4cplus/appender.h
@@ -98,7 +98,7 @@ namespace log4cplus {
      *
      * <dt><tt>filters</tt></dt>
      * <dd>This property specifies possibly multiple filters used by
-     * Appender. Each of multple filters and its properties is under a
+     * Appender. Each of multiple filters and its properties is under a
      * numbered subkey of filters key. E.g.:
      * <tt>filters.<em>1</em>=log4cplus::spi::LogLevelMatchFilter</tt>. Filter
      * subkey numbers must be consecutive.</dd>

--- a/include/log4cplus/configurator.h
+++ b/include/log4cplus/configurator.h
@@ -136,7 +136,7 @@ namespace log4cplus
          * # Set appender specific options.
          * log4cplus.appender.appenderName.option1=value1
          * ...
-         * log4cplus.appender.appenderName.optionN=valueN
+         * log4cplus.appender.appenderName.option&lt;N&gt;=value&lt;N&gt;
          * </pre>
          *
          * For each named appender you can configure its {@link Layout}. The
@@ -145,7 +145,7 @@ namespace log4cplus
          * log4cplus.appender.appenderName.layout=fully.qualified.name.of.layout.class
          * log4cplus.appender.appenderName.layout.option1=value1
          * ....
-         * log4cplus.appender.appenderName.layout.optionN=valueN
+         * log4cplus.appender.appenderName.layout.option&lt;N&gt;=value&lt;N&gt;
          * </pre>
          *
          * <h3>Configuring loggers</h3>
@@ -232,7 +232,7 @@ namespace log4cplus
          * # milliseconds, followed by the LogLevel of the log request,
          * # followed by the two rightmost components of the logger name,
          * # followed by the callers method name, followed by the line number,
-         * # the nested disgnostic context and finally the message itself.
+         * # the nested diagnostic context and finally the message itself.
          * # Refer to the documentation of {@link PatternLayout} for further information
          * # on the syntax of the ConversionPattern key.
          * log4cplus.appender.A1.layout=log4cplus::PatternLayout

--- a/include/log4cplus/fileappender.h
+++ b/include/log4cplus/fileappender.h
@@ -299,7 +299,7 @@ namespace log4cplus
      *
      * <dt><tt>DatePattern</tt></dt>
      * <dd>This property specifies filename suffix pattern to use for
-     * periodical backups of the logfile. The patern should be in
+     * periodical backups of the logfile. The pattern should be in
      * format supported by {@link log4cplus::helpers::Time::getFormatterTime()}</code>.
      * Please notice that the format of the pattern is similar but not identical
      * to the one used for this option in the corresponding Log4J class.

--- a/include/log4cplus/helpers/stringhelper.h
+++ b/include/log4cplus/helpers/stringhelper.h
@@ -112,7 +112,7 @@ namespace log4cplus {
                 // positive counterpart instead.  Also, in twos
                 // complement arithmetic the smallest negative number
                 // does not have positive counterpart; the range is
-                // asymetric.  That's why we handle the case of value
+                // asymmetric.  That's why we handle the case of value
                 // == min() specially here.
                 if (value == (std::numeric_limits<intType>::min) ()) [[unlikely]]
                 {

--- a/include/log4cplus/internal/customloglevelmanager.h
+++ b/include/log4cplus/internal/customloglevelmanager.h
@@ -30,8 +30,8 @@
 //  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /** @file
- * This header contains declaration internal to log4cplus. They must never be
- * visible from user accesible headers or exported in DLL/shared library.
+ * This header contains declarations internal to log4cplus. They must never be
+ * visible from user accessible headers or exported in a DLL/shared library.
  */
 
 

--- a/include/log4cplus/internal/internal.h
+++ b/include/log4cplus/internal/internal.h
@@ -29,8 +29,8 @@
 //  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /** @file
- * This header contains declaration internal to log4cplus. They must never be
- * visible from user accesible headers or exported in DLL/shared libray.
+ * This header contains declarations internal to log4cplus. They must never be
+ * visible from user accessible headers or exported in a DLL/shared library.
  */
 
 

--- a/include/log4cplus/internal/socket.h
+++ b/include/log4cplus/internal/socket.h
@@ -29,8 +29,8 @@
 //  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /** @file
- * This header contains declaration internal to log4cplus. They must never be
- * visible from user accesible headers or exported in DLL/shared libray.
+ * This header contains declarations internal to log4cplus. They must never be
+ * visible from user accessible headers or exported in a DLL/shared library.
  */
 
 

--- a/include/log4cplus/layout.h
+++ b/include/log4cplus/layout.h
@@ -432,7 +432,7 @@ namespace log4cplus {
      *
      * <tr>
      *   <td align=center><b>r</b></td>
-     *   <td>Used to output miliseconds since program start
+     *   <td>Used to output milliseconds since program start
      *   of the logging event.</td>
      * </tr>
      *
@@ -473,7 +473,7 @@ namespace log4cplus {
      *   <td>Used to output the MDC (mapped diagnostic context)
      *   associated with the thread that generated the logging
      *   event. It takes optional key parameter. Without the key
-     *   paramter (%%X), it outputs the whole MDC map. With the key
+     *   parameter (%%X), it outputs the whole MDC map. With the key
      *   (%%X{key}), it outputs just the key's value.
      *   </td>
      * </tr>

--- a/include/log4cplus/logger.h
+++ b/include/log4cplus/logger.h
@@ -63,7 +63,7 @@ namespace log4cplus
 
     /**
      * This is the central class in the log4cplus package. One of the
-     * distintive features of log4cplus are hierarchical loggers and their
+     * distinctive features of log4cplus are hierarchical loggers and their
      * evaluation.
      */
     class LOG4CPLUS_EXPORT Logger
@@ -136,7 +136,7 @@ namespace log4cplus
         /**
          * Calling this method will <em>safely</em> close and remove all
          * appenders in all the loggers including root contained in the
-         * default hierachy.
+         * default hierarchy.
          *
          * Some appenders such as SocketAppender need to be closed before the
          * application exits. Otherwise, pending logging events might be
@@ -231,7 +231,7 @@ namespace log4cplus
         void setLogLevel(LogLevel ll);
 
         /**
-         * Return the the {@link Hierarchy} where this <code>Logger</code> instance is
+         * Return the {@link Hierarchy} where this <code>Logger</code> instance is
          * attached.
          */
         Hierarchy& getHierarchy() const;

--- a/include/log4cplus/ndc.h
+++ b/include/log4cplus/ndc.h
@@ -64,9 +64,9 @@ namespace log4cplus {
      * affect the NDC of the <em>current</em> thread only. NDCs of other
      * threads remain unaffected.
      *
-     * For example, a server can build a per client request NDC
-     * consisting the clients host name and other information contained in
-     * the the request. <em>Cookies</em> are another source of distinctive
+     * For example, a server can build a per-client request NDC
+     * consisting of the client's host name and other information contained in
+     * the request. <em>Cookies</em> are another source of distinctive
      * information. To build an NDC one uses the {@link #push}
      * operation. Simply put,
      *

--- a/include/log4cplus/socketappender.h
+++ b/include/log4cplus/socketappender.h
@@ -68,17 +68,17 @@ namespace log4cplus
      *   <li>If the remote server is down, the logging requests are
      *   simply dropped. However, if and when the server comes back up,
      *   then event transmission is resumed transparently. This
-     *   transparent reconneciton is performed by a <em>connector</em>
+     *   transparent reconnection is performed by a <em>connector</em>
      *   thread which periodically attempts to connect to the server.
      *
      *   <li>Logging events are automatically <em>buffered</em> by the
-     *   native TCP implementation. This means that if the link to server
+     *   native TCP implementation. This means that if the link to the server
      *   is slow but still faster than the rate of (log) event production
      *   by the client, the client will not be affected by the slow
      *   network connection. However, if the network connection is slower
      *   then the rate of event production, then the client can only
      *   progress at the network rate. In particular, if the network link
-     *   to the the server is down, the client will be blocked.
+     *   to the server is down, the client will be blocked.
      *
      *   <li>On the other hand, if the network link is up, but the server
      *   is down, the client will not be blocked when making log requests

--- a/include/log4cplus/spi/filter.h
+++ b/include/log4cplus/spi/filter.h
@@ -218,7 +218,7 @@ namespace log4cplus {
          * minimum acceptable LogLevel (ie a LogLevel is never rejected for
          * being too "low"/unimportant).  If <code>LogLevelMax</code> is not
          * defined, then there is no maximum acceptable LogLevel (ie a
-         * LogLevel is never rejected for beeing too "high"/important).
+         * LogLevel is never rejected for being too "high"/important).
          *
          * Refer to the {@link
          * Appender#setThreshold setThreshold} method

--- a/include/log4cplus/spi/loggerimpl.h
+++ b/include/log4cplus/spi/loggerimpl.h
@@ -45,7 +45,7 @@ namespace log4cplus {
 
         /**
          * This is the central class in the log4cplus package. One of the
-         * distintive features of log4cplus are hierarchical loggers and their
+         * distinctive features of log4cplus are hierarchical loggers and their
          * evaluation.
          */
         class LOG4CPLUS_EXPORT LoggerImpl
@@ -116,7 +116,7 @@ namespace log4cplus {
             void setLogLevel(LogLevel _ll) { this->ll = _ll; }
 
             /**
-             * Return the the {@link Hierarchy} where this <code>Logger</code>
+             * Return the {@link Hierarchy} where this <code>Logger</code>
              * instance is attached.
              */
             virtual Hierarchy& getHierarchy() const;

--- a/include/log4cplus/spi/rootlogger.h
+++ b/include/log4cplus/spi/rootlogger.h
@@ -36,7 +36,7 @@ namespace log4cplus {
     namespace spi {
 
         /**
-         * RootLogger sits at the top of the logger hierachy. It is a
+         * RootLogger sits at the top of the logger hierarchy. It is a
          * regular logger except that it provides several guarantees.
          *
          * First, it cannot be assigned a <code>NOT_SET_LOG_LEVEL</code>

--- a/src/hierarchy.cxx
+++ b/src/hierarchy.cxx
@@ -326,7 +326,7 @@ Hierarchy::updateParents(Logger const & logger)
     bool parentFound = false;
     tstring substr;
 
-    // if name = "w.x.y.z", loop thourgh "w.x.y", "w.x" and "w", but not "w.x.y.z"
+    // if name = "w.x.y.z", loop through "w.x.y", "w.x" and "w", but not "w.x.y.z"
     for(std::size_t i=name.find_last_of(LOG4CPLUS_TEXT('.'), length-1);
         i != tstring::npos && i > 0;
         i = name.find_last_of(LOG4CPLUS_TEXT('.'), i-1))

--- a/src/hierarchylocker.cxx
+++ b/src/hierarchylocker.cxx
@@ -40,7 +40,7 @@ HierarchyLocker::HierarchyLocker(Hierarchy& _h)
     // Get a copy of all of the Hierarchy's Loggers (except the Root Logger)
     h.initializeLoggerList(loggerList);
 
-    // Lock all of the Hierarchy's Loggers' mutexs
+    // Lock all of the Hierarchy's Loggers' mutexes
     LoggerList::iterator it;
     try
     {

--- a/src/loggingevent.cxx
+++ b/src/loggingevent.cxx
@@ -143,7 +143,7 @@ InternalLoggingEvent::setLoggingEvent (const log4cplus::tstring_view & logger,
     LogLevel loglevel, const log4cplus::tstring_view & msg,
     const char * filename, int fline, const char * function_)
 {
-    // This could be imlemented using the swap idiom:
+    // This could be implemented using the swap idiom:
     //
     // InternalLoggingEvent (logger, loglevel, msg, filename, fline).swap (*this);
     //

--- a/src/patternlayout.cxx
+++ b/src/patternlayout.cxx
@@ -219,7 +219,7 @@ private:
 };
 
 
-//! This pattern is used to format miliseconds since process start.
+//! This pattern is used to format milliseconds since process start.
 class RelativeTimestampConverter: public PatternConverter {
 public:
     explicit RelativeTimestampConverter(const FormattingInfo& info);
@@ -516,7 +516,7 @@ LoggerPatternConverter::convert(tstring & result,
     else {
         auto len = name.length();
 
-        // We substract 1 from 'len' when assigning to 'end' to avoid out of
+        // We subtract 1 from 'len' when assigning to 'end' to avoid out of
         // bounds exception in return r.substring(end+1, len). This can happen
         // if precision is 1 and the logger name ends with a dot.
         auto end = len - 1;

--- a/src/property.cxx
+++ b/src/property.cxx
@@ -194,7 +194,7 @@ imbue_file_from_flags ([[maybe_unused]] tistream & file, unsigned flags)
  * Perform variable substitution in string <code>val</code> from
  * environment variables.
  *
- * <p>The variable substitution delimeters are <b>${</b> and <b>}</b>.
+ * <p>The variable substitution delimiters are <b>${</b> and <b>}</b>.
  *
  * <p>For example, if the System properties contains "key=value", then
  * the call
@@ -288,7 +288,7 @@ substVars (tstring & dest, const tstring & val,
                 i = var_start + replacement.size ();
         }
         else
-            // Nothing has been subtituted, just move beyond the
+            // Nothing has been substituted, just move beyond the
             // unexpanded variable.
             i = var_end + DELIM_STOP_LEN;
     } // end while loop


### PR DESCRIPTION
## Summary
- fix typos and grammar in project comments

## Testing
- `./scripts/fix-timestamps.sh`
- `../configure --enable-unit-tests --with-working-locale` *(fails: C++23 compiler required)*

------
https://chatgpt.com/codex/tasks/task_e_684204dd52708320bef051ded135796d