### PR TITLE
Fix QT5 mention in QT6 code.

### DIFF
--- a/qt6debugappender/CMakeLists.txt
+++ b/qt6debugappender/CMakeLists.txt
@@ -31,7 +31,7 @@ else ()
   set_target_properties (${qt6debugappender} PROPERTIES
     SOVERSION "${log4cplus_soversion}")
 endif ()
-target_compile_definitions (${qt6debugappender} PRIVATE INSIDE_LOG4CPLUS_QT5DEBUGAPPENDER)
+target_compile_definitions (${qt6debugappender} PRIVATE INSIDE_LOG4CPLUS_QT6DEBUGAPPENDER)
 
 if (APPLE)
   set_target_properties (${log4cplus} PROPERTIES


### PR DESCRIPTION
## Summary
- replace Qt5 macro name with Qt6 macro name in Qt6 appender CMake file

## Testing
- `cmake -S . -B build` *(fails: cannot find source file `catch_amalgamated.cpp`)*

------
https://chatgpt.com/codex/tasks/task_e_6866a69db8148320990705d4de773bd6