### PR TITLE
Add includes for Qt6 files

### DIFF
--- a/include/log4cplus/qt6messagehandler.h
+++ b/include/log4cplus/qt6messagehandler.h
@@ -43,6 +43,7 @@
 #endif
 
 #include <QtCore>
+#include <type_traits>
 
 #if defined (_WIN32)
   #if defined (log4cplusqt6debugappender_EXPORTS) \

--- a/qt6debugappender/qt6debugappender.cxx
+++ b/qt6debugappender/qt6debugappender.cxx
@@ -35,6 +35,7 @@
 #include <log4cplus/spi/factory.h>
 #include <log4cplus/spi/loggingevent.h>
 #include <log4cplus/logger.h>
+#include <cstdlib>
 #include <sstream>
 #include <iomanip>
 #include <QtGlobal>


### PR DESCRIPTION
## Summary
- add `#include <type_traits>` to qt6messagehandler
- include `<cstdlib>` in qt6debugappender

## Testing
- `./configure --enable-tests` *(fails: A compiler with support for C++23 language features is required)*

------
https://chatgpt.com/codex/tasks/task_e_6866a69ef8048320965c303a96380c17