### PR TITLE
Add ARM and Windows GitHub Actions builds

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -21,6 +21,16 @@ jobs:
           configure_flags: '--with-qt6'
           build-type: autotools
 
+
+        - os: 'ubuntu-24.04-arm'
+          cc: 'gcc'
+          cxx: 'g++'
+          prereq: |
+            sudo apt update
+            sudo apt install pkgconf
+          configure_flags: ''
+          build-type: cmake
+
         # Enable macOS build by installing Boost via Homebrew
         - os: 'macos-15'
           cc: 'clang'
@@ -125,3 +135,32 @@ jobs:
           exit 1
         ;;
         esac
+
+  windows-cmake:
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+        - os: 'windows-2022'
+          arch: 'x64'
+        - os: 'windows-11-arm'
+          arch: 'ARM64'
+
+    runs-on: ${{ matrix.config.os }}
+
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        submodules: recursive
+    - name: configure
+      run: >
+        cmake
+        -S .
+        -B objdir
+        -G "Visual Studio 17 2022"
+        -A ${{ matrix.config.arch }}
+        -DCMAKE_BUILD_TYPE=Release
+    - name: build
+      run: cmake --build objdir --config Release
+    - name: test
+      run: ctest --test-dir objdir --build-config Release --output-on-failure


### PR DESCRIPTION
### Motivation

- Increase CI coverage by adding native Linux ARM64 and Windows ARM64 build legs to catch platform-specific issues earlier.
- Verify the project builds with CMake on Ubuntu ARM64 and with Visual Studio 2022 on both Windows x64 and Windows AArch64.

### Description

- Updated `.github/workflows/c-cpp.yml` to add a `ubuntu-24.04-arm` matrix entry that uses the CMake build path and installs minimal prerequisites.
- Added a new `windows-cmake` job that runs CMake with the `"Visual Studio 17 2022"` generator for `windows-2022`/`x64` and `windows-11-arm`/`ARM64` and performs build and test steps via `cmake --build` and `ctest`.
- Kept the existing build matrix and autotools/ macOS entries unchanged and integrated the new jobs so tests run alongside the existing CI legs.

### Testing

- Parsed the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/c-cpp.yml")'` and the parse succeeded.
- Linted the workflow using `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/c-cpp.yml` and no actionlint errors were reported.
- Ran `git diff --check` to validate formatting/whitespace and it returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2844cb0c248320b259eaacd4ae9afb)