### PR TITLE
Add BSD GitHub Actions CI builds (FreeBSD/OpenBSD/NetBSD/DragonFly)

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -127,7 +127,7 @@ jobs:
         ;;
         #(
         cmake)
-          ctest --test-dir .
+          ctest --test-dir . --output-on-failure
         ;;
         #(
         *) 
@@ -176,7 +176,7 @@ jobs:
           cmake)
               cmake ..
               cmake --build .
-              ctest --test-dir .
+              ctest --test-dir . --output-on-failure
           ;;
           #(
           *)
@@ -225,7 +225,7 @@ jobs:
           cmake)
               cmake ..
               cmake --build .
-              ctest --test-dir .
+              ctest --test-dir . --output-on-failure
           ;;
           #(
           *)
@@ -275,7 +275,7 @@ jobs:
           cmake)
               cmake -DCMAKE_C_COMPILER="${CC}" -DCMAKE_CXX_COMPILER="${CXX}" ..
               cmake --build .
-              ctest --test-dir .
+              ctest --test-dir . --output-on-failure
           ;;
           #(
           *)
@@ -323,7 +323,7 @@ jobs:
           cmake)
               cmake -DCMAKE_C_COMPILER="${CC}" -DCMAKE_CXX_COMPILER="${CXX}" ..
               cmake --build .
-              ctest --test-dir .
+              ctest --test-dir . --output-on-failure
           ;;
           #(
           *)

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -136,6 +136,194 @@ jobs:
         ;;
         esac
 
+  freebsd:
+    strategy:
+      fail-fast: false
+      matrix:
+        release: ["15.0", "14.4", "13.5"]
+        build-type: [cmake, autotools]
+    runs-on: ubuntu-latest
+    name: ${{ matrix.build-type == 'cmake' && 'CMake' || 'Autotools' }} / FreeBSD ${{ matrix.release }}
+
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        submodules: recursive
+    - name: Build and test on FreeBSD
+      uses: vmactions/freebsd-vm@v1
+      with:
+        release: ${{ matrix.release }}
+        usesh: true
+        prepare: |
+          pkg install -y cmake autoconf automake libtool gmake pkgconf
+        run: |
+          set -e
+          c++ --version
+          ./scripts/fix-timestamps.sh
+          mkdir objdir
+          cd objdir
+          buildtype="${{ matrix.build-type }}"
+          case "${buildtype}" in #(
+          autotools)
+              ../configure CC="cc" CXX="c++" \
+                  --enable-shared --enable-unit-tests --with-working-locale
+              ./config.status --config
+              gmake
+              gmake check
+          ;;
+          #(
+          cmake)
+              cmake ..
+              cmake --build .
+              ctest --test-dir .
+          ;;
+          #(
+          *)
+              echo "Unsupported build type: ${buildtype}"
+              exit 1
+          ;;
+          esac
+
+  openbsd:
+    strategy:
+      fail-fast: false
+      matrix:
+        build-type: [cmake, autotools]
+    runs-on: ubuntu-latest
+    name: ${{ matrix.build-type == 'cmake' && 'CMake' || 'Autotools' }} / OpenBSD
+
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        submodules: recursive
+    - name: Build and test on OpenBSD
+      uses: vmactions/openbsd-vm@v1
+      with:
+        usesh: true
+        prepare: |
+          pkg_add cmake autoconf automake libtool gmake pkgconf
+        run: |
+          set -e
+          export AUTOCONF_VERSION=2.72
+          export AUTOMAKE_VERSION=1.16
+          c++ --version
+          ./scripts/fix-timestamps.sh
+          mkdir objdir
+          cd objdir
+          buildtype="${{ matrix.build-type }}"
+          case "${buildtype}" in #(
+          autotools)
+              ../configure CC="cc" CXX="c++" \
+                  --enable-shared --enable-unit-tests --with-working-locale
+              ./config.status --config
+              gmake
+              gmake check
+          ;;
+          #(
+          cmake)
+              cmake ..
+              cmake --build .
+              ctest --test-dir .
+          ;;
+          #(
+          *)
+              echo "Unsupported build type: ${buildtype}"
+              exit 1
+          ;;
+          esac
+
+  netbsd:
+    strategy:
+      fail-fast: false
+      matrix:
+        build-type: [cmake, autotools]
+    runs-on: ubuntu-latest
+    name: ${{ matrix.build-type == 'cmake' && 'CMake' || 'Autotools' }} / NetBSD
+
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        submodules: recursive
+    - name: Build and test on NetBSD
+      uses: vmactions/netbsd-vm@v1
+      with:
+        usesh: true
+        prepare: |
+          pkgin -y install cmake autoconf automake libtool gmake pkgconf
+        run: |
+          set -e
+          c++ --version
+          ./scripts/fix-timestamps.sh
+          mkdir objdir
+          cd objdir
+          buildtype="${{ matrix.build-type }}"
+          case "${buildtype}" in #(
+          autotools)
+              ../configure CC="cc" CXX="c++" \
+                  --enable-shared --enable-unit-tests --with-working-locale
+              ./config.status --config
+              gmake
+              gmake check
+          ;;
+          #(
+          cmake)
+              cmake ..
+              cmake --build .
+              ctest --test-dir .
+          ;;
+          #(
+          *)
+              echo "Unsupported build type: ${buildtype}"
+              exit 1
+          ;;
+          esac
+
+  dragonflybsd:
+    strategy:
+      fail-fast: false
+      matrix:
+        build-type: [cmake, autotools]
+    runs-on: ubuntu-latest
+    name: ${{ matrix.build-type == 'cmake' && 'CMake' || 'Autotools' }} / DragonFly BSD
+
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        submodules: recursive
+    - name: Build and test on DragonFly BSD
+      uses: vmactions/dragonflybsd-vm@v1
+      with:
+        usesh: true
+        prepare: |
+          pkg install -y cmake autoconf automake libtool gmake pkgconf
+        run: |
+          set -e
+          c++ --version
+          ./scripts/fix-timestamps.sh
+          mkdir objdir
+          cd objdir
+          buildtype="${{ matrix.build-type }}"
+          case "${buildtype}" in #(
+          autotools)
+              ../configure CC="cc" CXX="c++" \
+                  --enable-shared --enable-unit-tests --with-working-locale
+              ./config.status --config
+              gmake
+              gmake check
+          ;;
+          #(
+          cmake)
+              cmake ..
+              cmake --build .
+              ctest --test-dir .
+          ;;
+          #(
+          *)
+              echo "Unsupported build type: ${buildtype}"
+              exit 1
+          ;;
+          esac
+
   windows-cmake:
     strategy:
       fail-fast: false

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -249,7 +249,8 @@ jobs:
       with:
         usesh: true
         prepare: |
-          pkgin -y install cmake autoconf automake libtool gmake pkgconf
+          export PKG_PATH="https://cdn.NetBSD.org/pub/pkgsrc/packages/NetBSD/$(uname -p)/$(uname -r | cut -d_ -f1)/All"
+          pkg_add cmake autoconf automake libtool gmake pkgconf
         run: |
           set -e
           c++ --version

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -202,7 +202,7 @@ jobs:
       with:
         usesh: true
         prepare: |
-          pkg_add cmake autoconf automake libtool gmake pkgconf
+          pkg_add cmake autoconf automake libtool gmake pkgconf boost
         run: |
           set -e
           export AUTOCONF_VERSION=2.72
@@ -214,7 +214,8 @@ jobs:
           buildtype="${{ matrix.build-type }}"
           case "${buildtype}" in #(
           autotools)
-              ../configure CC="cc" CXX="c++" \
+              ../configure CPPFLAGS="-I/usr/local/include" LDFLAGS="-L/usr/local/lib" \
+                  CC="cc" CXX="c++" \
                   --enable-shared --enable-unit-tests --with-working-locale
               ./config.status --config
               gmake
@@ -251,7 +252,7 @@ jobs:
         usesh: true
         prepare: |
           export PKG_PATH="https://cdn.NetBSD.org/pub/pkgsrc/packages/NetBSD/$(uname -p)/$(uname -r | cut -d_ -f1)/All"
-          pkg_add cmake autoconf automake libtool gmake pkgconf gcc14
+          pkg_add cmake autoconf automake libtool gmake pkgconf boost-headers boost-libs gcc14
         run: |
           set -e
           export CC=/usr/pkg/gcc14/bin/gcc
@@ -263,7 +264,8 @@ jobs:
           buildtype="${{ matrix.build-type }}"
           case "${buildtype}" in #(
           autotools)
-              ../configure CC="${CC}" CXX="${CXX}" \
+              ../configure CPPFLAGS="-I/usr/pkg/include" LDFLAGS="-L/usr/pkg/lib" \
+                  CC="${CC}" CXX="${CXX}" \
                   --enable-shared --enable-unit-tests --with-working-locale
               ./config.status --config
               gmake

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -299,11 +299,11 @@ jobs:
       with:
         usesh: true
         prepare: |
-          pkg install -y cmake autoconf automake libtool gmake pkgconf gcc13
+          pkg install -y cmake autoconf automake libtool gmake pkgconf gcc14
         run: |
           set -e
-          export CC=gcc13
-          export CXX=g++13
+          export CC=gcc14
+          export CXX=g++14
           ${CXX} --version
           ./scripts/fix-timestamps.sh
           mkdir objdir

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -155,7 +155,7 @@ jobs:
         release: ${{ matrix.release }}
         usesh: true
         prepare: |
-          pkg install -y cmake autoconf automake libtool gmake pkgconf boost-libs
+          pkg install -y cmake autoconf automake libtool gmake pkgconf boost-all
         run: |
           set -e
           c++ --version
@@ -165,7 +165,8 @@ jobs:
           buildtype="${{ matrix.build-type }}"
           case "${buildtype}" in #(
           autotools)
-              ../configure CC="cc" CXX="c++" \
+              ../configure CPPFLAGS="-I/usr/local/include" LDFLAGS="-L/usr/local/lib" \
+                  CC="cc" CXX="c++" \
                   --enable-shared --enable-unit-tests --with-working-locale
               ./config.status --config
               gmake
@@ -253,8 +254,8 @@ jobs:
           pkg_add cmake autoconf automake libtool gmake pkgconf gcc13
         run: |
           set -e
-          export CC=gcc13
-          export CXX=g++13
+          export CC=/usr/pkg/gcc13/bin/gcc
+          export CXX=/usr/pkg/gcc13/bin/g++
           ${CXX} --version
           ./scripts/fix-timestamps.sh
           mkdir objdir

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -251,11 +251,11 @@ jobs:
         usesh: true
         prepare: |
           export PKG_PATH="https://cdn.NetBSD.org/pub/pkgsrc/packages/NetBSD/$(uname -p)/$(uname -r | cut -d_ -f1)/All"
-          pkg_add cmake autoconf automake libtool gmake pkgconf gcc13
+          pkg_add cmake autoconf automake libtool gmake pkgconf gcc14
         run: |
           set -e
-          export CC=/usr/pkg/gcc13/bin/gcc
-          export CXX=/usr/pkg/gcc13/bin/g++
+          export CC=/usr/pkg/gcc14/bin/gcc
+          export CXX=/usr/pkg/gcc14/bin/g++
           ${CXX} --version
           ./scripts/fix-timestamps.sh
           mkdir objdir

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -301,12 +301,13 @@ jobs:
       with:
         usesh: true
         prepare: |
-          pkg install -y cmake autoconf automake libtool gmake pkgconf gcc14
+          pkg install -y cmake autoconf automake libtool gmake pkgconf boost-all gcc14
         run: |
           set -e
           export CC=gcc14
           export CXX=g++14
-          export LDFLAGS="-Wl,-rpath=/usr/local/lib/gcc14"
+          export CPPFLAGS="-I/usr/local/include"
+          export LDFLAGS="-L/usr/local/lib -Wl,-rpath=/usr/local/lib/gcc14"
           ${CXX} --version
           ./scripts/fix-timestamps.sh
           mkdir objdir
@@ -314,7 +315,7 @@ jobs:
           buildtype="${{ matrix.build-type }}"
           case "${buildtype}" in #(
           autotools)
-              ../configure LDFLAGS="${LDFLAGS}" \
+              ../configure CPPFLAGS="${CPPFLAGS}" LDFLAGS="${LDFLAGS}" \
                   CC="${CC}" CXX="${CXX}" \
                   --enable-shared --enable-unit-tests --with-working-locale
               ./config.status --config

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -155,7 +155,7 @@ jobs:
         release: ${{ matrix.release }}
         usesh: true
         prepare: |
-          pkg install -y cmake autoconf automake libtool gmake pkgconf
+          pkg install -y cmake autoconf automake libtool gmake pkgconf boost-libs
         run: |
           set -e
           c++ --version
@@ -250,17 +250,19 @@ jobs:
         usesh: true
         prepare: |
           export PKG_PATH="https://cdn.NetBSD.org/pub/pkgsrc/packages/NetBSD/$(uname -p)/$(uname -r | cut -d_ -f1)/All"
-          pkg_add cmake autoconf automake libtool gmake pkgconf
+          pkg_add cmake autoconf automake libtool gmake pkgconf gcc13
         run: |
           set -e
-          c++ --version
+          export CC=gcc13
+          export CXX=g++13
+          ${CXX} --version
           ./scripts/fix-timestamps.sh
           mkdir objdir
           cd objdir
           buildtype="${{ matrix.build-type }}"
           case "${buildtype}" in #(
           autotools)
-              ../configure CC="cc" CXX="c++" \
+              ../configure CC="${CC}" CXX="${CXX}" \
                   --enable-shared --enable-unit-tests --with-working-locale
               ./config.status --config
               gmake
@@ -268,7 +270,7 @@ jobs:
           ;;
           #(
           cmake)
-              cmake ..
+              cmake -DCMAKE_C_COMPILER="${CC}" -DCMAKE_CXX_COMPILER="${CXX}" ..
               cmake --build .
               ctest --test-dir .
           ;;
@@ -296,17 +298,19 @@ jobs:
       with:
         usesh: true
         prepare: |
-          pkg install -y cmake autoconf automake libtool gmake pkgconf
+          pkg install -y cmake autoconf automake libtool gmake pkgconf gcc13
         run: |
           set -e
-          c++ --version
+          export CC=gcc13
+          export CXX=g++13
+          ${CXX} --version
           ./scripts/fix-timestamps.sh
           mkdir objdir
           cd objdir
           buildtype="${{ matrix.build-type }}"
           case "${buildtype}" in #(
           autotools)
-              ../configure CC="cc" CXX="c++" \
+              ../configure CC="${CC}" CXX="${CXX}" \
                   --enable-shared --enable-unit-tests --with-working-locale
               ./config.status --config
               gmake
@@ -314,7 +318,7 @@ jobs:
           ;;
           #(
           cmake)
-              cmake ..
+              cmake -DCMAKE_C_COMPILER="${CC}" -DCMAKE_CXX_COMPILER="${CXX}" ..
               cmake --build .
               ctest --test-dir .
           ;;

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -306,6 +306,7 @@ jobs:
           set -e
           export CC=gcc14
           export CXX=g++14
+          export LDFLAGS="-Wl,-rpath=/usr/local/lib/gcc14"
           ${CXX} --version
           ./scripts/fix-timestamps.sh
           mkdir objdir
@@ -313,7 +314,8 @@ jobs:
           buildtype="${{ matrix.build-type }}"
           case "${buildtype}" in #(
           autotools)
-              ../configure CC="${CC}" CXX="${CXX}" \
+              ../configure LDFLAGS="${LDFLAGS}" \
+                  CC="${CC}" CXX="${CXX}" \
                   --enable-shared --enable-unit-tests --with-working-locale
               ./config.status --config
               gmake
@@ -321,7 +323,9 @@ jobs:
           ;;
           #(
           cmake)
-              cmake -DCMAKE_C_COMPILER="${CC}" -DCMAKE_CXX_COMPILER="${CXX}" ..
+              cmake -DCMAKE_C_COMPILER="${CC}" -DCMAKE_CXX_COMPILER="${CXX}" \
+                  -DCMAKE_EXE_LINKER_FLAGS="${LDFLAGS}" \
+                  -DCMAKE_SHARED_LINKER_FLAGS="${LDFLAGS}" ..
               cmake --build .
               ctest --test-dir . --output-on-failure
           ;;


### PR DESCRIPTION
### Motivation
- Extend existing C/C++ CI to run on BSD platforms so releases can be validated on FreeBSD, OpenBSD, NetBSD and DragonFly BSD. 
- Provide both build variants used elsewhere in CI: `cmake` and `autotools`. 
- Reuse the repository's established build/test flow to keep behavior consistent across platforms. 

### Description
- Updated the existing CI workflow file ` .github/workflows/c-cpp.yml` to add BSD jobs for FreeBSD, OpenBSD, NetBSD and DragonFly BSD integrated into the same C/C++ workflow. 
- Added a FreeBSD matrix with releases `15.0`, `14.4`, and `13.5`, each running both `cmake` and `autotools` variants, and single `cmake`/`autotools` matrices for OpenBSD, NetBSD and DragonFly BSD. 
- Each BSD job uses the corresponding VM action (`vmactions/freebsd-vm`, `vmactions/openbsd-vm`, `vmactions/netbsd-vm`, `vmactions/dragonflybsd-vm`) and installs build dependencies with the native package manager: `pkg` (FreeBSD/DragonFly), `pkg_add` (OpenBSD), and `pkgin` (NetBSD). 
- Reused the project build/test steps: for CMake `cmake ..`, `cmake --build .`, `ctest --test-dir .`; for Autotools `../configure CC="cc" CXX="c++" --enable-shared --enable-unit-tests --with-working-locale`, `./config.status --config`, then `gmake` and `gmake check` on BSD. 

### Testing
- Validated the modified workflow YAML parses with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/c-cpp.yml"); puts "ok"'`, which returned `ok`. 
- Linted the workflow with `actionlint .github/workflows/c-cpp.yml`, which reported no issues. 
- The workflow was kept consistent with existing CI style and naming conventions and no automated CI test runs were executed here beyond the YAML and lint checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2edf6b97b88320bff4a5ea86bef535)